### PR TITLE
Add separate builder for journalbeat

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ build:
 	@make -C go1.11 $@
 	@make -C go1.11 -f Makefile.debian7 $@
 	@make -C fpm $@
+	@make -C go1.10-journalbeat $@
+	@make -C go1.10-journalbeat -f Makefile.debian7 $@
 
 # Requires login at https://docker.elastic.co:7000/.
 push:

--- a/go1.10-journalbeat/Makefile
+++ b/go1.10-journalbeat/Makefile
@@ -1,0 +1,10 @@
+IMAGES := base main
+
+build:
+	@$(foreach var,$(IMAGES),$(MAKE) -C $(var) build || exit 1;)
+
+# Requires login at https://docker.elastic.co:7000/.
+push:
+	@$(foreach var,$(IMAGES),$(MAKE) -C $(var) push || exit 1;)
+
+.PHONY: build push

--- a/go1.10-journalbeat/Makefile.common
+++ b/go1.10-journalbeat/Makefile.common
@@ -1,0 +1,23 @@
+SELF_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
+include $(SELF_DIR)/../Makefile.common
+
+NAME           := golang-crossbuild
+VERSION        := 1.10.3
+DEBIAN_VERSION ?= 9
+SUFFIX         := -$(shell basename $(CURDIR))
+TAG_EXTENSION  ?= -journalbeat
+
+build:
+	@echo ">> Building $(REPOSITORY)/$(NAME):$(VERSION)$(SUFFIX)$(TAG_EXTENSION)"
+	@docker build -t "$(REPOSITORY)/$(NAME):$(VERSION)$(SUFFIX)$(TAG_EXTENSION)" \
+  --build-arg REPOSITORY=$(REPOSITORY) \
+  --build-arg VERSION=$(VERSION) \
+  --build-arg DEBIAN_VERSION=$(DEBIAN_VERSION) \
+  --build-arg TAG_EXTENSION=$(TAG_EXTENSION) \
+	--build-arg IMAGE="$(REPOSITORY)/$(NAME):$(VERSION)$(SUFFIX)$(TAG_EXTENSION)" \
+	--build-arg VCS_REF="$(VCS_REF)" \
+	--build-arg VCS_URL="$(VCS_URL)" \
+	--build-arg BUILD_DATE="$(BUILD_DATE)" \
+	.
+
+.PHONY: build

--- a/go1.10-journalbeat/Makefile.debian7
+++ b/go1.10-journalbeat/Makefile.debian7
@@ -1,0 +1,14 @@
+IMAGES         := base main
+DEBIAN_VERSION := 7
+TAG_EXTENSION  := -debian7-journalbeat
+
+export DEBIAN_VERSION TAG_EXTENSION
+
+build:
+	@$(foreach var,$(IMAGES),$(MAKE) -C $(var) build || exit 1;)
+
+# Requires login at https://docker.elastic.co:7000/.
+push:
+	@$(foreach var,$(IMAGES),$(MAKE) -C $(var) push || exit 1;)
+
+.PHONY: build push

--- a/go1.10-journalbeat/base/.dockerignore
+++ b/go1.10-journalbeat/base/.dockerignore
@@ -1,0 +1,1 @@
+Makefile

--- a/go1.10-journalbeat/base/Dockerfile
+++ b/go1.10-journalbeat/base/Dockerfile
@@ -1,0 +1,10 @@
+ARG VERSION
+ARG REPOSITORY
+FROM ${REPOSITORY}/golang-crossbuild:${VERSION}-base
+
+RUN \
+    apt-get update \
+        && apt-get dist-upgrade -y \
+        && apt-get install -y --no-install-recommends \
+            libsystemd-dev \
+        && rm -rf /var/lib/apt/lists/*

--- a/go1.10-journalbeat/base/Makefile
+++ b/go1.10-journalbeat/base/Makefile
@@ -1,0 +1,1 @@
+include ../Makefile.common

--- a/go1.10-journalbeat/base/rootfs/entrypoint.go
+++ b/go1.10-journalbeat/base/rootfs/entrypoint.go
@@ -1,0 +1,175 @@
+// +build linux
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "crossbuild",
+	Short: "crossbuild is simple tool for cross-compiling Go binaries",
+	Long: `crossbuild is a containerized tool for cross-compiling Go binaries
+by mounting the project inside of a container equipped with cross-compilers.
+
+The root of your project's repo should be mounted at the appropriate location
+on the GOPATH which is set to /go.
+
+While executing the build command the following variables with be added to the
+environment: GOOS, GOARCH, GOARM, PLATFORM_ID, CC, and CXX.
+`,
+	RunE:         doBuild,
+	SilenceUsage: true,
+}
+
+func init() {
+	rootCmd.PersistentFlags().StringVarP(&buildCommand, "build-cmd", "c",
+		"make build", "Build command to execute.")
+
+	rootCmd.PersistentFlags().StringSliceVarP(&platforms, "platforms", "p", nil,
+		"Target platform for the binary in GOOS/GOARCH format (e.g. windows/amd64).")
+	rootCmd.MarkPersistentFlagRequired("platforms")
+}
+
+func main() {
+	log.SetFlags(0)
+
+	if err := rootCmd.Execute(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+var (
+	buildCommand string
+	platforms    []string
+)
+
+func doBuild(_ *cobra.Command, _ []string) error {
+	for _, p := range platforms {
+		env, err := buildEnvironment(p)
+		if err != nil {
+			return fmt.Errorf("failed constructing the build environment for %v: %v", p, err)
+		}
+
+		if err = execBuildCommand(env); err != nil {
+			return fmt.Errorf("failed building for %v: %v", p, err)
+		}
+	}
+
+	return nil
+}
+
+func isDirEmpty(name string) (bool, error) {
+	f, err := os.Open(name)
+	if err != nil {
+		return false, err
+	}
+	defer f.Close()
+
+	_, err = f.Readdirnames(1)
+	if err == io.EOF {
+		return true, nil
+	}
+	return false, err
+}
+
+func buildEnvironment(platform string) (map[string]string, error) {
+	parts := strings.SplitN(platform, "/", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid platform %v", platform)
+	}
+
+	platformID := strings.Join(parts, "-")
+	goos := parts[0]
+	arch := parts[1]
+	goarch := arch
+	goarm := ""
+
+	if strings.HasPrefix(arch, "armv") {
+		goarch = "arm"
+		goarm = strings.TrimPrefix(arch, "armv")
+	}
+
+	env := map[string]string{
+		"GOOS":        goos,
+		"GOARCH":      goarch,
+		"GOARM":       goarm,
+		"PLATFORM_ID": platformID,
+	}
+
+	if err := loadCompilerSettings(goos, arch, env); err != nil {
+		return nil, fmt.Errorf("failed while loading compiler settings: %v", err)
+	}
+
+	return env, nil
+}
+
+type Compilers struct {
+	GOOS map[string]struct {
+		Arch map[string]struct {
+			Env map[string]string `yaml:",inline"`
+		} `yaml:",inline"`
+	} `yaml:",inline"`
+}
+
+func loadCompilerSettings(goos, arch string, env map[string]string) error {
+	data, err := ioutil.ReadFile("/compilers.yaml")
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to read /compilers.yaml: %v", err)
+	}
+
+	var compilers Compilers
+	if err = yaml.Unmarshal(data, &compilers); err != nil {
+		return fmt.Errorf("failed to parse /compilers.yaml: %v", err)
+	}
+
+	arches, found := compilers.GOOS[goos]
+	if !found {
+		return fmt.Errorf("%v is not supported by this image", goos)
+	}
+
+	settings, found := arches.Arch[arch]
+	if !found {
+		return fmt.Errorf("%v/%v is not supported by this image", goos, arch)
+	}
+
+	for k, v := range settings.Env {
+		env[k] = v
+	}
+
+	return nil
+}
+
+func execBuildCommand(env map[string]string) error {
+	cmd := exec.Command("sh", "-c", buildCommand)
+	cmd.Env = os.Environ()
+	logEnv := make([]string, 0, len(env))
+	for k, v := range env {
+		kv := k + "=" + v
+		cmd.Env = append(cmd.Env, kv)
+		logEnv = append(logEnv, kv)
+	}
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
+
+	var b strings.Builder
+	sort.Strings(logEnv)
+	fmt.Fprintf(&b, ">> Building using: cmd='%v', env=[%v]", buildCommand, strings.Join(logEnv, ", "))
+
+	log.Println(b.String())
+	return cmd.Run()
+}

--- a/go1.10-journalbeat/main/.dockerignore
+++ b/go1.10-journalbeat/main/.dockerignore
@@ -1,0 +1,1 @@
+Makefile

--- a/go1.10-journalbeat/main/Dockerfile
+++ b/go1.10-journalbeat/main/Dockerfile
@@ -1,0 +1,28 @@
+ARG REPOSITORY
+ARG VERSION
+ARG TAG_EXTENSION=
+FROM ${REPOSITORY}/golang-crossbuild:${VERSION}-base${TAG_EXTENSION}
+
+RUN \
+    dpkg --add-architecture i386 \
+    && apt-get update && apt-get install -y --no-install-recommends \
+        g++ \
+        gcc \
+        gcc-multilib \
+        libc6-dev \
+        patch \
+        xz-utils \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY rootfs /
+
+# Build-time metadata as defined at http://label-schema.org.
+ARG BUILD_DATE
+ARG IMAGE
+ARG VCS_REF
+ARG VCS_URL
+LABEL org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.name=$IMAGE \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.vcs-url=$VCS_URL \
+      org.label-schema.schema-version="1.0"

--- a/go1.10-journalbeat/main/Makefile
+++ b/go1.10-journalbeat/main/Makefile
@@ -1,0 +1,1 @@
+include ../Makefile.common

--- a/go1.10-journalbeat/main/rootfs/compilers.yaml
+++ b/go1.10-journalbeat/main/rootfs/compilers.yaml
@@ -1,0 +1,9 @@
+---
+
+linux:
+  386:
+    CC:  gcc
+    CXX: g++
+  amd64:
+    CC:  gcc
+    CXX: g++


### PR DESCRIPTION
New separate `Dockerfile` is added to build `journalbeat`. I introduced a new builder, because the vendored lib which accesses journals requires `libsystemd-dev` package. I would like to keep general builder images minimal. As right now `journalbeat` is the only one which requires this package, I do not want to install it in all containers.

The tag of the new image is suffixed with `-journalbeat`. I made builder tag suffixes configurable in `mage` of Beats. I will open the PR in Beats after this PR is merged.