### PR TITLE
Update sources.list for Debian 8

### DIFF
--- a/go1.10/base/Dockerfile.tmpl
+++ b/go1.10/base/Dockerfile.tmpl
@@ -1,7 +1,7 @@
 ARG DEBIAN_VERSION
 FROM debian:${DEBIAN_VERSION}
 
-{{if eq .DEBIAN_VERSION "7" -}}
+{{if or (eq .DEBIAN_VERSION "7") (eq .DEBIAN_VERSION "8") -}}
 # Replace sources.list in order to use archive.debian.org.
 COPY sources-debian{{.DEBIAN_VERSION}}.list /etc/apt/sources.list
 {{end -}}

--- a/go1.10/base/sources-debian8.list
+++ b/go1.10/base/sources-debian8.list
@@ -1,0 +1,2 @@
+deb http://archive.debian.org/debian jessie main
+deb http://security.debian.org/debian-security jessie/updates main

--- a/go1.11/base/Dockerfile.tmpl
+++ b/go1.11/base/Dockerfile.tmpl
@@ -1,10 +1,10 @@
 ARG DEBIAN_VERSION
 FROM debian:${DEBIAN_VERSION}
 
-{{if eq .DEBIAN_VERSION "7" -}}
+{{if or (eq .DEBIAN_VERSION "7") (eq .DEBIAN_VERSION "8") -}}
 # Replace sources.list in order to use archive.debian.org.
 COPY sources-debian{{.DEBIAN_VERSION}}.list /etc/apt/sources.list
-{{end -}}
+{{- end}}
 
 RUN \
     apt-get update \

--- a/go1.11/base/sources-debian8.list
+++ b/go1.11/base/sources-debian8.list
@@ -1,0 +1,2 @@
+deb http://archive.debian.org/debian jessie main
+deb http://security.debian.org/debian-security jessie/updates main


### PR DESCRIPTION
Follow on to #16. At the time of that change Jessie was still working,
now it's not.