### PR TITLE
Fix the fpm targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
-GO_VERSIONS=go1.10 go1.11 go1.12
-TARGETS=$(GO_VERSIONS) fpm
+TARGETS=go1.10 go1.11 go1.12
 
 build:
 	@$(foreach var,$(TARGETS), \
 		$(MAKE) -C $(var) $@; \
 		$(MAKE) -C $(var) -f Makefile.debian7 $@; \
 		$(MAKE) -C $(var) -f Makefile.debian8 $@;)
+	@make -C fpm $@
 
 # Requires login at https://docker.elastic.co:7000/.
 push:
@@ -13,5 +13,6 @@ push:
 		$(MAKE) -C $(var) $@; \
 		$(MAKE) -C $(var) -f Makefile.debian7 $@; \
 		$(MAKE) -C $(var) -f Makefile.debian8 $@;)
+	@make -C fpm $@
 
 .PHONY: build push


### PR DESCRIPTION
Just build fpm out of the target loop, so we don't have to check if the `Makefile.debian*` exists, since we rarely change fpm we should build it often.