### PR TITLE
Pin parent image to stretch rather than stable

### DIFF
--- a/fpm/Dockerfile.tmpl
+++ b/fpm/Dockerfile.tmpl
@@ -1,4 +1,4 @@
-FROM debian:stable
+FROM debian:stretch
 LABEL maintainer="Elastic Beats Team"
 
 RUN \


### PR DESCRIPTION
stable changed to buster and buster included a newer rpm package and now
the rpmbuild is including files like

    /usr/lib/.build-id/9d/3614c9a48200641b24890671bea43ef43c760b

in our packages. So we'll base this image on stretch and then update
all the things using the container to include

    --rpm-rpmbuild-define "_build_id_links none"

when building RPMs to prevent those files from being included. Then
we can update.

https://github.com/jordansissel/fpm/issues/1503