### PR TITLE
Update to Go 1.11.13, 1.12.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,16 +12,16 @@ The base image used is Debian 9 (stretch) unless otherwise specified.
 
 ## Build Tags
 
-- `1.10.8-main`, `1.11.12-main`, `1.12.7-main` - linux/{amd64,386} and windows/{amd64,386}
-- `1.10.8-arm`, `1.11.12-arm`, `1.12.7-arm` - linux/{armv5,armv6,armv7,arm64}
-- `1.10.8-darwin`, `1.11.12-darwin`, `1.12.7-darwin` - darwin/{amd64,386}
-- `1.10.8-ppc`, `1.11.12-ppc`, `1.12.7-ppc` - linux/{ppc64,ppc64le}
-- `1.10.8-mips`, `1.11.12-mips`, `1.12.7-mips` - linux/{mips,mipsle,mips64,mips64le}
-- `1.10.8-s390x`, `1.11.12-s390x`, `1.12.7-s390` - linux/s390x
-- `1.10.8-main-debian7`, `1.11.12-main-debian7`, `1.12.7-debian7` - linux/{amd64,386} and windows/{amd64,386} (Debian 7
+- `1.10.8-main`, `1.11.13-main`, `1.12.8-main` - linux/{amd64,386} and windows/{amd64,386}
+- `1.10.8-arm`, `1.11.13-arm`, `1.12.8-arm` - linux/{armv5,armv6,armv7,arm64}
+- `1.10.8-darwin`, `1.11.13-darwin`, `1.12.8-darwin` - darwin/{amd64,386}
+- `1.10.8-ppc`, `1.11.13-ppc`, `1.12.8-ppc` - linux/{ppc64,ppc64le}
+- `1.10.8-mips`, `1.11.13-mips`, `1.12.8-mips` - linux/{mips,mipsle,mips64,mips64le}
+- `1.10.8-s390x`, `1.11.13-s390x`, `1.12.8-s390` - linux/s390x
+- `1.10.8-main-debian7`, `1.11.13-main-debian7`, `1.12.8-debian7` - linux/{amd64,386} and windows/{amd64,386} (Debian 7
   uses glibc 2.13 so the resulting binaries (if dynamically linked) have greater
   compatibility.)
-- `1.10.8-main-debian8`, `1.11.12-main-debian8`, `1.12.7-main-debian8` - linux/{amd64,386} and windows/{amd64,386} (Debian 8
+- `1.10.8-main-debian8`, `1.11.13-main-debian8`, `1.12.8-main-debian8` - linux/{amd64,386} and windows/{amd64,386} (Debian 8
   uses glibc 2.19)
 
 ## Usage Example
@@ -52,6 +52,6 @@ GOARM, PLATFORM_ID, CC, and CXX.
 1. Update the versions listed in this README.md.
 1. Commit the changes. `git add -u && git commit -m 'Update to Go 1.x.y'`.
 1. Build the images from the project's root with `make`.
-1. Get a logon token for the container registry by visiting <https://docker.elastic.co:7000.>
+1. Get a logon token for the container registry by visiting <https://docker.elastic.co:7000>.
    In the provided login command change `docker.elastic.co` to `push.docker.elastic.co`.
 1. Publish the images with `make push`.

--- a/go1.11/Makefile.common
+++ b/go1.11/Makefile.common
@@ -2,7 +2,7 @@ SELF_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 include $(SELF_DIR)/../Makefile.common
 
 NAME           := golang-crossbuild
-VERSION        := 1.11.12
+VERSION        := 1.11.13
 DEBIAN_VERSION ?= 9
 SUFFIX         := -$(shell basename $(CURDIR))
 TAG_EXTENSION  ?=

--- a/go1.11/base/Dockerfile.tmpl
+++ b/go1.11/base/Dockerfile.tmpl
@@ -21,9 +21,9 @@ RUN \
             bison \
         && rm -rf /var/lib/apt/lists/*
 
-ARG GOLANG_VERSION=1.11.12
+ARG GOLANG_VERSION=1.11.13
 ARG GOLANG_DOWNLOAD_URL=https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
-ARG GOLANG_DOWNLOAD_SHA256=14ec881815eb9e6618f95df5eb385d961283efc196d97912595ba6484a56180d
+ARG GOLANG_DOWNLOAD_SHA256=50fe8e13592f8cf22304b9c4adfc11849a2c3d281b1d7e09c924ae24874c6daa
 
 RUN curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz \
 	&& echo "$GOLANG_DOWNLOAD_SHA256  golang.tar.gz" | sha256sum -c - \

--- a/go1.12/Makefile.common
+++ b/go1.12/Makefile.common
@@ -2,7 +2,7 @@ SELF_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 include $(SELF_DIR)/../Makefile.common
 
 NAME           := golang-crossbuild
-VERSION        := 1.12.7
+VERSION        := 1.12.8
 DEBIAN_VERSION ?= 9
 SUFFIX         := -$(shell basename $(CURDIR))
 TAG_EXTENSION  ?=

--- a/go1.12/base/Dockerfile.tmpl
+++ b/go1.12/base/Dockerfile.tmpl
@@ -21,9 +21,9 @@ RUN \
             bison \
         && rm -rf /var/lib/apt/lists/*
 
-ARG GOLANG_VERSION=1.12.7
+ARG GOLANG_VERSION=1.12.8
 ARG GOLANG_DOWNLOAD_URL=https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
-ARG GOLANG_DOWNLOAD_SHA256=66d83bfb5a9ede000e33c6579a91a29e6b101829ad41fffb5c5bb6c900e109d9
+ARG GOLANG_DOWNLOAD_SHA256=bd26cd4962a362ed3c11835bca32c2e131c2ae050304f2c4df9fa6ded8db85d2
 
 RUN curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz \
 	&& echo "$GOLANG_DOWNLOAD_SHA256  golang.tar.gz" | sha256sum -c - \


### PR DESCRIPTION
 Includes security fixes to the net/http and net/url packages.