### PR TITLE
Update Go to 1.13.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,16 +12,16 @@ The base image used is Debian 9 (stretch) unless otherwise specified.
 
 ## Build Tags
 
-- `1.10.8-main`, `1.11.13-main`, `1.12.12-main`, `1.13.5-main` - linux/{amd64,386} and windows/{amd64,386}
-- `1.10.8-arm`, `1.11.13-arm`, `1.12.12-arm`, `1.13.5-arm` - linux/{armv5,armv6,armv7,arm64}
-- `1.10.8-darwin`, `1.11.13-darwin`, `1.12.12-darwin, `1.13.5-darwin`` - darwin/{amd64,386}
-- `1.10.8-ppc`, `1.11.13-ppc`, `1.12.12-ppc`, `1.13.5-ppc` - linux/{ppc64,ppc64le}
-- `1.10.8-mips`, `1.11.13-mips`, `1.12.12-mips, `1.13.5-mips`` - linux/{mips,mipsle,mips64,mips64le}
-- `1.10.8-s390x`, `1.11.13-s390x`, `1.12.12-s390, `1.13.5-s390`` - linux/s390x
-- `1.10.8-main-debian7`, `1.11.13-main-debian7`, `1.12.12-debian7, `1.13.5-debian7`` - linux/{amd64,386} and windows/{amd64,386} (Debian 7
+- `1.10.8-main`, `1.11.13-main`, `1.12.12-main`, `1.13.6-main` - linux/{amd64,386} and windows/{amd64,386}
+- `1.10.8-arm`, `1.11.13-arm`, `1.12.12-arm`, `1.13.6-arm` - linux/{armv5,armv6,armv7,arm64}
+- `1.10.8-darwin`, `1.11.13-darwin`, `1.12.12-darwin, `1.13.6-darwin`` - darwin/{amd64,386}
+- `1.10.8-ppc`, `1.11.13-ppc`, `1.12.12-ppc`, `1.13.6-ppc` - linux/{ppc64,ppc64le}
+- `1.10.8-mips`, `1.11.13-mips`, `1.12.12-mips, `1.13.6-mips`` - linux/{mips,mipsle,mips64,mips64le}
+- `1.10.8-s390x`, `1.11.13-s390x`, `1.12.12-s390, `1.13.6-s390`` - linux/s390x
+- `1.10.8-main-debian7`, `1.11.13-main-debian7`, `1.12.12-debian7, `1.13.6-debian7`` - linux/{amd64,386} and windows/{amd64,386} (Debian 7
   uses glibc 2.13 so the resulting binaries (if dynamically linked) have greater
   compatibility.)
-- `1.10.8-main-debian8`, `1.11.13-main-debian8`, `1.12.12-main-debian8, `1.13.5-debian8`` - linux/{amd64,386} and windows/{amd64,386} (Debian 8
+- `1.10.8-main-debian8`, `1.11.13-main-debian8`, `1.12.12-main-debian8, `1.13.6-debian8`` - linux/{amd64,386} and windows/{amd64,386} (Debian 8
   uses glibc 2.19)
 
 ## Usage Example

--- a/go1.13/Makefile.common
+++ b/go1.13/Makefile.common
@@ -2,7 +2,7 @@ SELF_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 include $(SELF_DIR)/../Makefile.common
 
 NAME           := golang-crossbuild
-VERSION        := 1.13.5
+VERSION        := 1.13.6
 DEBIAN_VERSION ?= 9
 SUFFIX         := -$(shell basename $(CURDIR))
 TAG_EXTENSION  ?=

--- a/go1.13/base/Dockerfile.tmpl
+++ b/go1.13/base/Dockerfile.tmpl
@@ -21,9 +21,9 @@ RUN \
             bison \
         && rm -rf /var/lib/apt/lists/*
 
-ARG GOLANG_VERSION=1.13.5
+ARG GOLANG_VERSION=1.13.6
 ARG GOLANG_DOWNLOAD_URL=https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
-ARG GOLANG_DOWNLOAD_SHA256=512103d7ad296467814a6e3f635631bd35574cab3369a97a323c9a585ccaa569
+ARG GOLANG_DOWNLOAD_SHA256=a1bc06deb070155c4f67c579f896a45eeda5a8fa54f35ba233304074c4abbbbd
 
 RUN curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz \
 	&& echo "$GOLANG_DOWNLOAD_SHA256  golang.tar.gz" | sha256sum -c - \


### PR DESCRIPTION
go1.13.6 (released 2020/01/09) includes fixes to the runtime and the net/http package.