### PR TITLE
Update Go to 1.13.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,16 +12,16 @@ The base image used is Debian 9 (stretch) unless otherwise specified.
 
 ## Build Tags
 
-- `1.10.8-main`, `1.11.13-main`, `1.12.12-main`, `1.13.7-main` - linux/{amd64,386} and windows/{amd64,386}
-- `1.10.8-arm`, `1.11.13-arm`, `1.12.12-arm`, `1.13.7-arm` - linux/{armv5,armv6,armv7,arm64}
-- `1.10.8-darwin`, `1.11.13-darwin`, `1.12.12-darwin, `1.13.7-darwin`` - darwin/{amd64,386}
-- `1.10.8-ppc`, `1.11.13-ppc`, `1.12.12-ppc`, `1.13.7-ppc` - linux/{ppc64,ppc64le}
-- `1.10.8-mips`, `1.11.13-mips`, `1.12.12-mips, `1.13.7-mips`` - linux/{mips,mipsle,mips64,mips64le}
-- `1.10.8-s390x`, `1.11.13-s390x`, `1.12.12-s390, `1.13.7-s390`` - linux/s390x
-- `1.10.8-main-debian7`, `1.11.13-main-debian7`, `1.12.12-debian7, `1.13.7-debian7`` - linux/{amd64,386} and windows/{amd64,386} (Debian 7
+- `1.10.8-main`, `1.11.13-main`, `1.12.12-main`, `1.13.8-main` - linux/{amd64,386} and windows/{amd64,386}
+- `1.10.8-arm`, `1.11.13-arm`, `1.12.12-arm`, `1.13.8-arm` - linux/{armv5,armv6,armv7,arm64}
+- `1.10.8-darwin`, `1.11.13-darwin`, `1.12.12-darwin, `1.13.8-darwin`` - darwin/{amd64,386}
+- `1.10.8-ppc`, `1.11.13-ppc`, `1.12.12-ppc`, `1.13.8-ppc` - linux/{ppc64,ppc64le}
+- `1.10.8-mips`, `1.11.13-mips`, `1.12.12-mips, `1.13.8-mips`` - linux/{mips,mipsle,mips64,mips64le}
+- `1.10.8-s390x`, `1.11.13-s390x`, `1.12.12-s390, `1.13.8-s390`` - linux/s390x
+- `1.10.8-main-debian7`, `1.11.13-main-debian7`, `1.12.12-debian7, `1.13.8-debian7`` - linux/{amd64,386} and windows/{amd64,386} (Debian 7
   uses glibc 2.13 so the resulting binaries (if dynamically linked) have greater
   compatibility.)
-- `1.10.8-main-debian8`, `1.11.13-main-debian8`, `1.12.12-main-debian8, `1.13.7-debian8`` - linux/{amd64,386} and windows/{amd64,386} (Debian 8
+- `1.10.8-main-debian8`, `1.11.13-main-debian8`, `1.12.12-main-debian8, `1.13.8-debian8`` - linux/{amd64,386} and windows/{amd64,386} (Debian 8
   uses glibc 2.19)
 
 ## Usage Example

--- a/go1.13/Makefile.common
+++ b/go1.13/Makefile.common
@@ -2,7 +2,7 @@ SELF_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 include $(SELF_DIR)/../Makefile.common
 
 NAME           := golang-crossbuild
-VERSION        := 1.13.7
+VERSION        := 1.13.8
 DEBIAN_VERSION ?= 9
 SUFFIX         := -$(shell basename $(CURDIR))
 TAG_EXTENSION  ?=

--- a/go1.13/base/Dockerfile.tmpl
+++ b/go1.13/base/Dockerfile.tmpl
@@ -21,9 +21,9 @@ RUN \
             bison \
         && rm -rf /var/lib/apt/lists/*
 
-ARG GOLANG_VERSION=1.13.7
+ARG GOLANG_VERSION=1.13.8
 ARG GOLANG_DOWNLOAD_URL=https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
-ARG GOLANG_DOWNLOAD_SHA256=b3dd4bd781a0271b33168e627f7f43886b4c5d1c794a4015abf34e99c6526ca3
+ARG GOLANG_DOWNLOAD_SHA256=0567734d558aef19112f2b2873caa0c600f1b4a5827930eb5a7f35235219e9d8
 
 RUN curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz \
 	&& echo "$GOLANG_DOWNLOAD_SHA256  golang.tar.gz" | sha256sum -c - \


### PR DESCRIPTION
go1.13.8 (released 2020/02/12) includes fixes to the runtime, the crypto/x509, and net/http packages.