### PR TITLE
Add SWIG to base images

### DIFF
--- a/go1.10/base/Dockerfile.tmpl
+++ b/go1.10/base/Dockerfile.tmpl
@@ -19,7 +19,9 @@ RUN \
             file \
             flex \
             bison \
+{{- if not (or (eq .DEBIAN_VERSION "7") (eq .DEBIAN_VERSION "8"))}}
             swig \
+{{- end}}
         && rm -rf /var/lib/apt/lists/*
 
 ARG GOLANG_VERSION=1.10.8

--- a/go1.10/base/Dockerfile.tmpl
+++ b/go1.10/base/Dockerfile.tmpl
@@ -19,6 +19,7 @@ RUN \
             file \
             flex \
             bison \
+            swig \
         && rm -rf /var/lib/apt/lists/*
 
 ARG GOLANG_VERSION=1.10.8

--- a/go1.11/base/Dockerfile.tmpl
+++ b/go1.11/base/Dockerfile.tmpl
@@ -19,7 +19,9 @@ RUN \
             file \
             flex \
             bison \
+{{- if not (or (eq .DEBIAN_VERSION "7") (eq .DEBIAN_VERSION "8"))}}
             swig \
+{{- end}}
         && rm -rf /var/lib/apt/lists/*
 
 ARG GOLANG_VERSION=1.11.13

--- a/go1.11/base/Dockerfile.tmpl
+++ b/go1.11/base/Dockerfile.tmpl
@@ -19,6 +19,7 @@ RUN \
             file \
             flex \
             bison \
+            swig \
         && rm -rf /var/lib/apt/lists/*
 
 ARG GOLANG_VERSION=1.11.13

--- a/go1.12/base/Dockerfile.tmpl
+++ b/go1.12/base/Dockerfile.tmpl
@@ -19,7 +19,9 @@ RUN \
             file \
             flex \
             bison \
+{{- if not (or (eq .DEBIAN_VERSION "7") (eq .DEBIAN_VERSION "8"))}}
             swig \
+{{- end}}
         && rm -rf /var/lib/apt/lists/*
 
 ARG GOLANG_VERSION=1.12.12

--- a/go1.12/base/Dockerfile.tmpl
+++ b/go1.12/base/Dockerfile.tmpl
@@ -19,6 +19,7 @@ RUN \
             file \
             flex \
             bison \
+            swig \
         && rm -rf /var/lib/apt/lists/*
 
 ARG GOLANG_VERSION=1.12.12

--- a/go1.13/base/Dockerfile.tmpl
+++ b/go1.13/base/Dockerfile.tmpl
@@ -19,6 +19,7 @@ RUN \
             file \
             flex \
             bison \
+            swig \
         && rm -rf /var/lib/apt/lists/*
 
 ARG GOLANG_VERSION=1.13.8

--- a/go1.13/base/Dockerfile.tmpl
+++ b/go1.13/base/Dockerfile.tmpl
@@ -19,7 +19,9 @@ RUN \
             file \
             flex \
             bison \
+{{- if not (or (eq .DEBIAN_VERSION "7") (eq .DEBIAN_VERSION "8"))}}
             swig \
+{{- end}}
         && rm -rf /var/lib/apt/lists/*
 
 ARG GOLANG_VERSION=1.13.8


### PR DESCRIPTION
SWIG is used by CGO to generate C++ bindings.

closes elastic/golang-crossbuild#42