### PR TITLE
Update Go to 1.14.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TARGETS=go1.10 go1.11 go1.12 go1.13
+TARGETS=go1.10 go1.11 go1.12 go1.13 go1.14
 
 build:
 	@$(foreach var,$(TARGETS), \

--- a/README.md
+++ b/README.md
@@ -12,16 +12,16 @@ The base image used is Debian 9 (stretch) unless otherwise specified.
 
 ## Build Tags
 
-- `1.10.8-main`, `1.11.13-main`, `1.12.12-main`, `1.13.8-main` - linux/{amd64,386} and windows/{amd64,386}
-- `1.10.8-arm`, `1.11.13-arm`, `1.12.12-arm`, `1.13.8-arm` - linux/{armv5,armv6,armv7,arm64}
-- `1.10.8-darwin`, `1.11.13-darwin`, `1.12.12-darwin, `1.13.8-darwin`` - darwin/{amd64,386}
-- `1.10.8-ppc`, `1.11.13-ppc`, `1.12.12-ppc`, `1.13.8-ppc` - linux/{ppc64,ppc64le}
-- `1.10.8-mips`, `1.11.13-mips`, `1.12.12-mips, `1.13.8-mips`` - linux/{mips,mipsle,mips64,mips64le}
-- `1.10.8-s390x`, `1.11.13-s390x`, `1.12.12-s390, `1.13.8-s390`` - linux/s390x
-- `1.10.8-main-debian7`, `1.11.13-main-debian7`, `1.12.12-debian7, `1.13.8-debian7`` - linux/{amd64,386} and windows/{amd64,386} (Debian 7
+- `1.10.8-main`, `1.11.13-main`, `1.12.12-main`, `1.13.8-main`, `1.14.0` - linux/{amd64,386} and windows/{amd64,386}
+- `1.10.8-arm`, `1.11.13-arm`, `1.12.12-arm`, `1.13.8-arm`, `1.14.0` - linux/{armv5,armv6,armv7,arm64}
+- `1.10.8-darwin`, `1.11.13-darwin`, `1.12.12-darwin`, `1.13.8-darwin`, `1.14.0` - darwin/{amd64,386}
+- `1.10.8-ppc`, `1.11.13-ppc`, `1.12.12-ppc`, `1.13.8-ppc`, `1.14.0` - linux/{ppc64,ppc64le}
+- `1.10.8-mips`, `1.11.13-mips`, `1.12.12-mips`, `1.13.8-mips`, `1.14.0` - linux/{mips,mipsle,mips64,mips64le}
+- `1.10.8-s390x`, `1.11.13-s390x`, `1.12.12-s390`, `1.13.8-s390`, `1.14.0` - linux/s390x
+- `1.10.8-main-debian7`, `1.11.13-main-debian7`, `1.12.12-debian7`, `1.13.8-debian7`, `1.14.0` - linux/{amd64,386} and windows/{amd64,386} (Debian 7
   uses glibc 2.13 so the resulting binaries (if dynamically linked) have greater
   compatibility.)
-- `1.10.8-main-debian8`, `1.11.13-main-debian8`, `1.12.12-main-debian8, `1.13.8-debian8`` - linux/{amd64,386} and windows/{amd64,386} (Debian 8
+- `1.10.8-main-debian8`, `1.11.13-main-debian8`, `1.12.12-main-debian8`, `1.13.8-debian8`, `1.14.0` - linux/{amd64,386} and windows/{amd64,386} (Debian 8
   uses glibc 2.19)
 
 ## Usage Example

--- a/go1.14/Makefile
+++ b/go1.14/Makefile
@@ -1,0 +1,10 @@
+IMAGES := base main darwin arm mips ppc s390x
+
+build:
+	@$(foreach var,$(IMAGES),$(MAKE) -C $(var) build || exit 1;)
+
+# Requires login at https://docker.elastic.co:7000/.
+push:
+	@$(foreach var,$(IMAGES),$(MAKE) -C $(var) push || exit 1;)
+
+.PHONY: build push

--- a/go1.14/Makefile.common
+++ b/go1.14/Makefile.common
@@ -1,0 +1,26 @@
+SELF_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
+include $(SELF_DIR)/../Makefile.common
+
+NAME           := golang-crossbuild
+VERSION        := 1.14.0
+DEBIAN_VERSION ?= 9
+SUFFIX         := -$(shell basename $(CURDIR))
+TAG_EXTENSION  ?=
+
+export DEBIAN_VERSION TAG_EXTENSION
+
+build:
+	@echo ">> Building $(REPOSITORY)/$(NAME):$(VERSION)$(SUFFIX)$(TAG_EXTENSION)"
+	@go run $(SELF_DIR)/../template.go -t Dockerfile.tmpl -o Dockerfile
+	@docker build -t "$(REPOSITORY)/$(NAME):$(VERSION)$(SUFFIX)$(TAG_EXTENSION)" \
+  --build-arg REPOSITORY=$(REPOSITORY) \
+  --build-arg VERSION=$(VERSION) \
+  --build-arg DEBIAN_VERSION=$(DEBIAN_VERSION) \
+  --build-arg TAG_EXTENSION=$(TAG_EXTENSION) \
+	--build-arg IMAGE="$(REPOSITORY)/$(NAME):$(VERSION)$(SUFFIX)$(TAG_EXTENSION)" \
+	--build-arg VCS_REF="$(VCS_REF)" \
+	--build-arg VCS_URL="$(VCS_URL)" \
+	--build-arg BUILD_DATE="$(BUILD_DATE)" \
+	.
+
+.PHONY: build

--- a/go1.14/Makefile.common
+++ b/go1.14/Makefile.common
@@ -13,10 +13,10 @@ build:
 	@echo ">> Building $(REPOSITORY)/$(NAME):$(VERSION)$(SUFFIX)$(TAG_EXTENSION)"
 	@go run $(SELF_DIR)/../template.go -t Dockerfile.tmpl -o Dockerfile
 	@docker build -t "$(REPOSITORY)/$(NAME):$(VERSION)$(SUFFIX)$(TAG_EXTENSION)" \
-  --build-arg REPOSITORY=$(REPOSITORY) \
-  --build-arg VERSION=$(VERSION) \
-  --build-arg DEBIAN_VERSION=$(DEBIAN_VERSION) \
-  --build-arg TAG_EXTENSION=$(TAG_EXTENSION) \
+	--build-arg REPOSITORY=$(REPOSITORY) \
+	--build-arg VERSION=$(VERSION) \
+	--build-arg DEBIAN_VERSION=$(DEBIAN_VERSION) \
+	--build-arg TAG_EXTENSION=$(TAG_EXTENSION) \
 	--build-arg IMAGE="$(REPOSITORY)/$(NAME):$(VERSION)$(SUFFIX)$(TAG_EXTENSION)" \
 	--build-arg VCS_REF="$(VCS_REF)" \
 	--build-arg VCS_URL="$(VCS_URL)" \

--- a/go1.14/Makefile.debian7
+++ b/go1.14/Makefile.debian7
@@ -1,0 +1,14 @@
+IMAGES         := base main
+DEBIAN_VERSION := 7
+TAG_EXTENSION  := -debian7
+
+export DEBIAN_VERSION TAG_EXTENSION
+
+build:
+	@$(foreach var,$(IMAGES),$(MAKE) -C $(var) build || exit 1;)
+
+# Requires login at https://docker.elastic.co:7000/.
+push:
+	@$(foreach var,$(IMAGES),$(MAKE) -C $(var) push || exit 1;)
+
+.PHONY: build push

--- a/go1.14/Makefile.debian8
+++ b/go1.14/Makefile.debian8
@@ -1,0 +1,14 @@
+IMAGES         := base main
+DEBIAN_VERSION := 8
+TAG_EXTENSION  := -debian8
+
+export DEBIAN_VERSION TAG_EXTENSION
+
+build:
+	@$(foreach var,$(IMAGES),$(MAKE) -C $(var) build || exit 1;)
+
+# Requires login at https://docker.elastic.co:7000/.
+push:
+	@$(foreach var,$(IMAGES),$(MAKE) -C $(var) push || exit 1;)
+
+.PHONY: build push

--- a/go1.14/arm/.dockerignore
+++ b/go1.14/arm/.dockerignore
@@ -1,0 +1,1 @@
+Makefile

--- a/go1.14/arm/Dockerfile.tmpl
+++ b/go1.14/arm/Dockerfile.tmpl
@@ -1,0 +1,26 @@
+ARG REPOSITORY
+ARG VERSION
+FROM ${REPOSITORY}/golang-crossbuild:${VERSION}-base
+
+RUN \
+    apt-get update && apt-get install -y --no-install-recommends \
+        crossbuild-essential-arm64 \
+        crossbuild-essential-armel \
+        crossbuild-essential-armhf \
+        linux-libc-dev-arm64-cross \
+        linux-libc-dev-armel-cross \
+        linux-libc-dev-armhf-cross \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY rootfs /
+
+# Build-time metadata as defined at http://label-schema.org.
+ARG BUILD_DATE
+ARG IMAGE
+ARG VCS_REF
+ARG VCS_URL
+LABEL org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.name=$IMAGE \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.vcs-url=$VCS_URL \
+      org.label-schema.schema-version="1.0"

--- a/go1.14/arm/Makefile
+++ b/go1.14/arm/Makefile
@@ -1,0 +1,1 @@
+include ../Makefile.common

--- a/go1.14/arm/rootfs/compilers.yaml
+++ b/go1.14/arm/rootfs/compilers.yaml
@@ -1,0 +1,17 @@
+---
+
+linux:
+  armv7:
+    CC:  arm-linux-gnueabihf-gcc
+    CXX: arm-linux-gnueabihf-g++
+  armv6:
+    # Using debian armel for ARMv6.
+    # This is the same as ARMv5 so it will use softfp instead of hardfp.
+    CC:  arm-linux-gnueabi-gcc
+    CXX: arm-linux-gnueabi-g++
+  armv5:
+    CC:  arm-linux-gnueabi-gcc
+    CXX: arm-linux-gnueabi-g++
+  arm64:
+    CC:  aarch64-linux-gnu-gcc
+    CXX: aarch64-linux-gnu-g++

--- a/go1.14/base/.dockerignore
+++ b/go1.14/base/.dockerignore
@@ -1,0 +1,1 @@
+Makefile

--- a/go1.14/base/Dockerfile.tmpl
+++ b/go1.14/base/Dockerfile.tmpl
@@ -21,7 +21,7 @@ RUN \
             bison \
         && rm -rf /var/lib/apt/lists/*
 
-ARG GOLANG_VERSION=1.14.0
+ARG GOLANG_VERSION=1.14
 ARG GOLANG_DOWNLOAD_URL=https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
 ARG GOLANG_DOWNLOAD_SHA256=08df79b46b0adf498ea9f320a0f23d6ec59e9003660b4c9c1ce8e5e2c6f823ca
 

--- a/go1.14/base/Dockerfile.tmpl
+++ b/go1.14/base/Dockerfile.tmpl
@@ -1,0 +1,49 @@
+ARG DEBIAN_VERSION
+FROM debian:${DEBIAN_VERSION}
+
+{{if or (eq .DEBIAN_VERSION "7") (eq .DEBIAN_VERSION "8") -}}
+# Replace sources.list in order to use archive.debian.org.
+COPY sources-debian{{.DEBIAN_VERSION}}.list /etc/apt/sources.list
+{{- end}}
+
+RUN \
+    apt-get -o Acquire::Check-Valid-Until=false update \
+        && apt-get dist-upgrade -y \
+        && apt-get install -y --no-install-recommends \
+            build-essential \
+            ca-certificates \
+            curl \
+            git \
+            gnupg \
+            make \
+            file \
+            flex \
+            bison \
+        && rm -rf /var/lib/apt/lists/*
+
+ARG GOLANG_VERSION=1.14.0
+ARG GOLANG_DOWNLOAD_URL=https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
+ARG GOLANG_DOWNLOAD_SHA256=08df79b46b0adf498ea9f320a0f23d6ec59e9003660b4c9c1ce8e5e2c6f823ca
+
+RUN curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz \
+	&& echo "$GOLANG_DOWNLOAD_SHA256  golang.tar.gz" | sha256sum -c - \
+	&& tar -C /usr/local -xzf golang.tar.gz \
+	&& rm golang.tar.gz
+
+ENV GOPATH /go
+ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
+
+RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
+WORKDIR $GOPATH
+
+COPY rootfs /
+
+WORKDIR /
+RUN go get -d . \
+    && go build -o /crossbuild /entrypoint.go \
+    && rm -rf /go/* /root/.cache/* /entrypoint.go
+
+ENV GOLANG_CROSSBUILD=1
+VOLUME      /app
+WORKDIR     /app
+ENTRYPOINT  ["/crossbuild"]

--- a/go1.14/base/Makefile
+++ b/go1.14/base/Makefile
@@ -1,0 +1,1 @@
+include ../Makefile.common

--- a/go1.14/base/rootfs/entrypoint.go
+++ b/go1.14/base/rootfs/entrypoint.go
@@ -1,0 +1,175 @@
+// +build linux
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "crossbuild",
+	Short: "crossbuild is simple tool for cross-compiling Go binaries",
+	Long: `crossbuild is a containerized tool for cross-compiling Go binaries
+by mounting the project inside of a container equipped with cross-compilers.
+
+The root of your project's repo should be mounted at the appropriate location
+on the GOPATH which is set to /go.
+
+While executing the build command the following variables with be added to the
+environment: GOOS, GOARCH, GOARM, PLATFORM_ID, CC, and CXX.
+`,
+	RunE:         doBuild,
+	SilenceUsage: true,
+}
+
+func init() {
+	rootCmd.PersistentFlags().StringVarP(&buildCommand, "build-cmd", "c",
+		"make build", "Build command to execute.")
+
+	rootCmd.PersistentFlags().StringSliceVarP(&platforms, "platforms", "p", nil,
+		"Target platform for the binary in GOOS/GOARCH format (e.g. windows/amd64).")
+	rootCmd.MarkPersistentFlagRequired("platforms")
+}
+
+func main() {
+	log.SetFlags(0)
+
+	if err := rootCmd.Execute(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+var (
+	buildCommand string
+	platforms    []string
+)
+
+func doBuild(_ *cobra.Command, _ []string) error {
+	for _, p := range platforms {
+		env, err := buildEnvironment(p)
+		if err != nil {
+			return fmt.Errorf("failed constructing the build environment for %v: %v", p, err)
+		}
+
+		if err = execBuildCommand(env); err != nil {
+			return fmt.Errorf("failed building for %v: %v", p, err)
+		}
+	}
+
+	return nil
+}
+
+func isDirEmpty(name string) (bool, error) {
+	f, err := os.Open(name)
+	if err != nil {
+		return false, err
+	}
+	defer f.Close()
+
+	_, err = f.Readdirnames(1)
+	if err == io.EOF {
+		return true, nil
+	}
+	return false, err
+}
+
+func buildEnvironment(platform string) (map[string]string, error) {
+	parts := strings.SplitN(platform, "/", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid platform %v", platform)
+	}
+
+	platformID := strings.Join(parts, "-")
+	goos := parts[0]
+	arch := parts[1]
+	goarch := arch
+	goarm := ""
+
+	if strings.HasPrefix(arch, "armv") {
+		goarch = "arm"
+		goarm = strings.TrimPrefix(arch, "armv")
+	}
+
+	env := map[string]string{
+		"GOOS":        goos,
+		"GOARCH":      goarch,
+		"GOARM":       goarm,
+		"PLATFORM_ID": platformID,
+	}
+
+	if err := loadCompilerSettings(goos, arch, env); err != nil {
+		return nil, fmt.Errorf("failed while loading compiler settings: %v", err)
+	}
+
+	return env, nil
+}
+
+type Compilers struct {
+	GOOS map[string]struct {
+		Arch map[string]struct {
+			Env map[string]string `yaml:",inline"`
+		} `yaml:",inline"`
+	} `yaml:",inline"`
+}
+
+func loadCompilerSettings(goos, arch string, env map[string]string) error {
+	data, err := ioutil.ReadFile("/compilers.yaml")
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to read /compilers.yaml: %v", err)
+	}
+
+	var compilers Compilers
+	if err = yaml.Unmarshal(data, &compilers); err != nil {
+		return fmt.Errorf("failed to parse /compilers.yaml: %v", err)
+	}
+
+	arches, found := compilers.GOOS[goos]
+	if !found {
+		return fmt.Errorf("%v is not supported by this image", goos)
+	}
+
+	settings, found := arches.Arch[arch]
+	if !found {
+		return fmt.Errorf("%v/%v is not supported by this image", goos, arch)
+	}
+
+	for k, v := range settings.Env {
+		env[k] = v
+	}
+
+	return nil
+}
+
+func execBuildCommand(env map[string]string) error {
+	cmd := exec.Command("sh", "-c", buildCommand)
+	cmd.Env = os.Environ()
+	logEnv := make([]string, 0, len(env))
+	for k, v := range env {
+		kv := k + "=" + v
+		cmd.Env = append(cmd.Env, kv)
+		logEnv = append(logEnv, kv)
+	}
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
+
+	var b strings.Builder
+	sort.Strings(logEnv)
+	fmt.Fprintf(&b, ">> Building using: cmd='%v', env=[%v]", buildCommand, strings.Join(logEnv, ", "))
+
+	log.Println(b.String())
+	return cmd.Run()
+}

--- a/go1.14/base/sources-debian7.list
+++ b/go1.14/base/sources-debian7.list
@@ -1,0 +1,2 @@
+deb http://archive.debian.org/debian wheezy main
+deb http://archive.debian.org/debian-security wheezy/updates main

--- a/go1.14/base/sources-debian8.list
+++ b/go1.14/base/sources-debian8.list
@@ -1,0 +1,2 @@
+deb http://archive.debian.org/debian jessie main
+deb http://security.debian.org/debian-security jessie/updates main

--- a/go1.14/darwin/Dockerfile.tmpl
+++ b/go1.14/darwin/Dockerfile.tmpl
@@ -1,0 +1,40 @@
+ARG REPOSITORY
+ARG VERSION
+FROM ${REPOSITORY}/golang-crossbuild:${VERSION}-base
+
+RUN \
+    apt-get update && apt-get install -y --no-install-recommends \
+        clang \
+        llvm \
+    && rm -rf /var/lib/apt/lists/*
+
+ARG OSXCROSS_SDK_URL=https://s3.amazonaws.com/beats-files/deps/MacOSX10.11.sdk.tar.xz
+ARG OSXCROSS_PATH=/usr/osxcross
+ARG OSXCROSS_REV=3034f7149716d815bc473d0a7b35d17e4cf175aa
+ARG SDK_VERSION=10.11
+ARG DARWIN_VERSION=15
+ARG OSX_VERSION_MIN=10.10
+
+RUN \
+    mkdir -p /tmp/osxcross && cd /tmp/osxcross \
+    && curl -sSL "https://codeload.github.com/tpoechtrager/osxcross/tar.gz/${OSXCROSS_REV}" \
+        | tar -C /tmp/osxcross --strip=1 -xzf - \
+    && curl -sSLo "tarballs/MacOSX${SDK_VERSION}.sdk.tar.xz" "${OSXCROSS_SDK_URL}" \
+    && UNATTENDED=yes ./build.sh >/dev/null \
+    && mv target "${OSXCROSS_PATH}" \
+    && rm -rf /tmp/osxcross "/usr/osxcross/SDK/MacOSX${SDK_VERSION}.sdk/usr/share/man"
+
+ENV PATH $OSXCROSS_PATH/bin:$PATH
+
+COPY rootfs /
+
+# Build-time metadata as defined at http://label-schema.org.
+ARG BUILD_DATE
+ARG IMAGE
+ARG VCS_REF
+ARG VCS_URL
+LABEL org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.name=$IMAGE \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.vcs-url=$VCS_URL \
+      org.label-schema.schema-version="1.0"

--- a/go1.14/darwin/Makefile
+++ b/go1.14/darwin/Makefile
@@ -1,0 +1,1 @@
+include ../Makefile.common

--- a/go1.14/darwin/rootfs/compilers.yaml
+++ b/go1.14/darwin/rootfs/compilers.yaml
@@ -1,0 +1,9 @@
+---
+
+darwin:
+  386:
+    CC:  o32-clang
+    CXX: o32-clang++
+  amd64:
+    CC:  o64-clang
+    CXX: o64-clang++

--- a/go1.14/main/.dockerignore
+++ b/go1.14/main/.dockerignore
@@ -1,0 +1,1 @@
+Makefile

--- a/go1.14/main/Dockerfile.tmpl
+++ b/go1.14/main/Dockerfile.tmpl
@@ -1,0 +1,34 @@
+ARG REPOSITORY
+ARG VERSION
+ARG TAG_EXTENSION=
+FROM ${REPOSITORY}/golang-crossbuild:${VERSION}-base${TAG_EXTENSION}
+
+RUN \
+    dpkg --add-architecture i386 \
+    && apt-get -o Acquire::Check-Valid-Until=false update \
+    && apt-get install -y --no-install-recommends \
+        clang \
+        g++ \
+        gcc \
+        gcc-multilib \
+        libc6-dev \
+        libc6-dev-i386 \
+        linux-libc-dev:i386 \
+        mingw-w64 \
+        mingw-w64-tools \
+        patch \
+        xz-utils \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY rootfs /
+
+# Build-time metadata as defined at http://label-schema.org.
+ARG BUILD_DATE
+ARG IMAGE
+ARG VCS_REF
+ARG VCS_URL
+LABEL org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.name=$IMAGE \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.vcs-url=$VCS_URL \
+      org.label-schema.schema-version="1.0"

--- a/go1.14/main/Makefile
+++ b/go1.14/main/Makefile
@@ -1,0 +1,1 @@
+include ../Makefile.common

--- a/go1.14/main/rootfs/compilers.yaml
+++ b/go1.14/main/rootfs/compilers.yaml
@@ -1,0 +1,25 @@
+---
+
+windows:
+  386:
+    CC:  i686-w64-mingw32-gcc
+    CXX: i686-w64-mingw32-g++
+  amd64:
+    CC:  x86_64-w64-mingw32-gcc
+    CXX: x86_64-w64-mingw32-g++
+
+darwin:
+  386:
+    CC:  o32-clang
+    CXX: o32-clang++
+  amd64:
+    CC:  o64-clang
+    CXX: o64-clang++
+
+linux:
+  386:
+    CC:  gcc
+    CXX: g++
+  amd64:
+    CC:  gcc
+    CXX: g++

--- a/go1.14/mips/.dockerignore
+++ b/go1.14/mips/.dockerignore
@@ -1,0 +1,1 @@
+Makefile

--- a/go1.14/mips/Dockerfile.tmpl
+++ b/go1.14/mips/Dockerfile.tmpl
@@ -1,0 +1,27 @@
+ARG REPOSITORY
+ARG VERSION
+FROM ${REPOSITORY}/golang-crossbuild:${VERSION}-base
+
+RUN \
+    apt-get update && apt-get install -y --no-install-recommends \
+        crossbuild-essential-mipsel \
+        gcc-mips-linux-gnu \
+        g++-mips-linux-gnu \
+        gcc-6-mips64-linux-gnuabi64 \
+        g++-6-mips64-linux-gnuabi64 \
+        gcc-6-mips64el-linux-gnuabi64 \
+        g++-6-mips64el-linux-gnuabi64 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY rootfs /
+
+# Build-time metadata as defined at http://label-schema.org.
+ARG BUILD_DATE
+ARG IMAGE
+ARG VCS_REF
+ARG VCS_URL
+LABEL org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.name=$IMAGE \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.vcs-url=$VCS_URL \
+      org.label-schema.schema-version="1.0"

--- a/go1.14/mips/Makefile
+++ b/go1.14/mips/Makefile
@@ -1,0 +1,1 @@
+include ../Makefile.common

--- a/go1.14/mips/rootfs/compilers.yaml
+++ b/go1.14/mips/rootfs/compilers.yaml
@@ -1,0 +1,15 @@
+---
+
+linux:
+  mips:
+    CC:  mips-linux-gnu-gcc
+    CXX: mips-linux-gnu-g++
+  mipsle:
+    CC:  mipsel-linux-gnu-gcc
+    CXX: mipsel-linux-gnu-g++
+  mips64:
+    CC:  mips64-linux-gnuabi64-gcc-6
+    CXX: mips64-linux-gnuabi64-g++-6
+  mips64le:
+    CC:  mips64el-linux-gnuabi64-gcc-6
+    CXX: mips64el-linux-gnuabi64-g++-6

--- a/go1.14/ppc/.dockerignore
+++ b/go1.14/ppc/.dockerignore
@@ -1,0 +1,1 @@
+Makefile

--- a/go1.14/ppc/Dockerfile.tmpl
+++ b/go1.14/ppc/Dockerfile.tmpl
@@ -1,0 +1,23 @@
+ARG REPOSITORY
+ARG VERSION
+FROM ${REPOSITORY}/golang-crossbuild:${VERSION}-base
+
+RUN \
+    apt-get update && apt-get install -y --no-install-recommends \
+        g++-6-powerpc64-linux-gnu \
+        gcc-6-powerpc64-linux-gnu \
+        crossbuild-essential-ppc64el \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY rootfs /
+
+# Build-time metadata as defined at http://label-schema.org.
+ARG BUILD_DATE
+ARG IMAGE
+ARG VCS_REF
+ARG VCS_URL
+LABEL org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.name=$IMAGE \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.vcs-url=$VCS_URL \
+      org.label-schema.schema-version="1.0"

--- a/go1.14/ppc/Makefile
+++ b/go1.14/ppc/Makefile
@@ -1,0 +1,1 @@
+include ../Makefile.common

--- a/go1.14/ppc/rootfs/compilers.yaml
+++ b/go1.14/ppc/rootfs/compilers.yaml
@@ -1,0 +1,9 @@
+---
+
+linux:
+  ppc64:
+    CC:  powerpc64-linux-gnu-gcc-6
+    CXX: powerpc64-linux-gnu-g++-6
+  ppc64le:
+    CC:  powerpc64le-linux-gnu-gcc
+    CXX: powerpc64le-linux-gnu-g++

--- a/go1.14/s390x/.dockerignore
+++ b/go1.14/s390x/.dockerignore
@@ -1,0 +1,1 @@
+Makefile

--- a/go1.14/s390x/Dockerfile.tmpl
+++ b/go1.14/s390x/Dockerfile.tmpl
@@ -1,0 +1,22 @@
+ARG REPOSITORY
+ARG VERSION
+FROM ${REPOSITORY}/golang-crossbuild:${VERSION}-base
+
+RUN \
+    apt-get update && apt-get install -y --no-install-recommends \
+        g++-s390x-linux-gnu \
+        gcc-s390x-linux-gnu \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY rootfs /
+
+# Build-time metadata as defined at http://label-schema.org.
+ARG BUILD_DATE
+ARG IMAGE
+ARG VCS_REF
+ARG VCS_URL
+LABEL org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.name=$IMAGE \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.vcs-url=$VCS_URL \
+      org.label-schema.schema-version="1.0"

--- a/go1.14/s390x/Makefile
+++ b/go1.14/s390x/Makefile
@@ -1,0 +1,1 @@
+include ../Makefile.common

--- a/go1.14/s390x/rootfs/compilers.yaml
+++ b/go1.14/s390x/rootfs/compilers.yaml
@@ -1,0 +1,6 @@
+---
+
+linux:
+  s390x:
+    CC:  s390x-linux-gnu-gcc
+    CXX: s390x-linux-gnu-g++


### PR DESCRIPTION
The highlights for Go 1.14 include:
- Module support in the go command is now ready for production use. We encourage all users to migrate to go modules for dependency management.
- Embedding interfaces with overlapping method sets
- Improved defer performance
- Goroutines are asynchronously preemptible
- The page allocator is more efficient
- Internal timers are more efficient

The complete list of changes can be found [here](https://golang.org/doc/go1.14).