### PR TITLE
Update to go 1.13.11, 1.14.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,16 +12,16 @@ The base image used is Debian 9 (stretch) unless otherwise specified.
 
 ## Build Tags
 
-- `1.10.8-main`, `1.11.13-main`, `1.12.12-main`, `1.13.10-main`, `1.14.2` - linux/{amd64,386} and windows/{amd64,386}
-- `1.10.8-arm`, `1.11.13-arm`, `1.12.12-arm`, `1.13.10-arm`, `1.14.2` - linux/{armv5,armv6,armv7,arm64}
-- `1.10.8-darwin`, `1.11.13-darwin`, `1.12.12-darwin`, `1.13.10-darwin`, `1.14.2` - darwin/{amd64,386}
-- `1.10.8-ppc`, `1.11.13-ppc`, `1.12.12-ppc`, `1.13.10-ppc`, `1.14.2` - linux/{ppc64,ppc64le}
-- `1.10.8-mips`, `1.11.13-mips`, `1.12.12-mips`, `1.13.10-mips`, `1.14.2` - linux/{mips,mipsle,mips64,mips64le}
-- `1.10.8-s390x`, `1.11.13-s390x`, `1.12.12-s390`, `1.13.10-s390`, `1.14.2` - linux/s390x
-- `1.10.8-main-debian7`, `1.11.13-main-debian7`, `1.12.12-debian7`, `1.13.10-debian7`, `1.14.2` - linux/{amd64,386} and windows/{amd64,386} (Debian 7
+- `1.10.8-main`, `1.11.13-main`, `1.12.12-main`, `1.13.11-main`, `1.14.3` - linux/{amd64,386} and windows/{amd64,386}
+- `1.10.8-arm`, `1.11.13-arm`, `1.12.12-arm`, `1.13.11-arm`, `1.14.3` - linux/{armv5,armv6,armv7,arm64}
+- `1.10.8-darwin`, `1.11.13-darwin`, `1.12.12-darwin`, `1.13.11-darwin`, `1.14.3` - darwin/{amd64,386}
+- `1.10.8-ppc`, `1.11.13-ppc`, `1.12.12-ppc`, `1.13.11-ppc`, `1.14.3` - linux/{ppc64,ppc64le}
+- `1.10.8-mips`, `1.11.13-mips`, `1.12.12-mips`, `1.13.11-mips`, `1.14.3` - linux/{mips,mipsle,mips64,mips64le}
+- `1.10.8-s390x`, `1.11.13-s390x`, `1.12.12-s390`, `1.13.11-s390`, `1.14.3` - linux/s390x
+- `1.10.8-main-debian7`, `1.11.13-main-debian7`, `1.12.12-debian7`, `1.13.11-debian7`, `1.14.3` - linux/{amd64,386} and windows/{amd64,386} (Debian 7
   uses glibc 2.13 so the resulting binaries (if dynamically linked) have greater
   compatibility.)
-- `1.10.8-main-debian8`, `1.11.13-main-debian8`, `1.12.12-main-debian8`, `1.13.10-debian8`, `1.14.2` - linux/{amd64,386} and windows/{amd64,386} (Debian 8
+- `1.10.8-main-debian8`, `1.11.13-main-debian8`, `1.12.12-main-debian8`, `1.13.11-debian8`, `1.14.3` - linux/{amd64,386} and windows/{amd64,386} (Debian 8
   uses glibc 2.19)
 
 ## Usage Example

--- a/go1.10/arm/Dockerfile.tmpl
+++ b/go1.10/arm/Dockerfile.tmpl
@@ -3,7 +3,7 @@ ARG VERSION
 FROM ${REPOSITORY}/golang-crossbuild:${VERSION}-base
 
 RUN \
-    apt-get update && apt-get install -y --no-install-recommends \
+    apt-get update && apt-get install -y --no-install-recommends --allow-unauthenticated \
         crossbuild-essential-arm64 \
         crossbuild-essential-armel \
         crossbuild-essential-armhf \

--- a/go1.10/base/Dockerfile.tmpl
+++ b/go1.10/base/Dockerfile.tmpl
@@ -9,7 +9,7 @@ COPY sources-debian{{.DEBIAN_VERSION}}.list /etc/apt/sources.list
 RUN \
     apt-get -o Acquire::Check-Valid-Until=false update \
         && apt-get dist-upgrade -y \
-        && apt-get install -y --no-install-recommends \
+        && apt-get install -y --no-install-recommends --allow-unauthenticated \
             build-essential \
             ca-certificates \
             curl \

--- a/go1.10/darwin/Dockerfile.tmpl
+++ b/go1.10/darwin/Dockerfile.tmpl
@@ -3,7 +3,7 @@ ARG VERSION
 FROM ${REPOSITORY}/golang-crossbuild:${VERSION}-base
 
 RUN \
-    apt-get update && apt-get install -y --no-install-recommends \
+    apt-get update && apt-get install -y --no-install-recommends --allow-unauthenticated \
         clang \
         llvm \
     && rm -rf /var/lib/apt/lists/*

--- a/go1.10/main/Dockerfile.tmpl
+++ b/go1.10/main/Dockerfile.tmpl
@@ -5,7 +5,7 @@ FROM ${REPOSITORY}/golang-crossbuild:${VERSION}-base${TAG_EXTENSION}
 
 RUN \
     dpkg --add-architecture i386 \
-    && apt-get -o Acquire::Check-Valid-Until=false update && apt-get install -y --no-install-recommends \
+    && apt-get -o Acquire::Check-Valid-Until=false update && apt-get install -y --no-install-recommends --allow-unauthenticated \
         clang \
         g++ \
         gcc \

--- a/go1.10/mips/Dockerfile.tmpl
+++ b/go1.10/mips/Dockerfile.tmpl
@@ -3,7 +3,7 @@ ARG VERSION
 FROM ${REPOSITORY}/golang-crossbuild:${VERSION}-base
 
 RUN \
-    apt-get update && apt-get install -y --no-install-recommends \
+    apt-get update && apt-get install -y --no-install-recommends --allow-unauthenticated \
         crossbuild-essential-mipsel \
         gcc-mips-linux-gnu \
         g++-mips-linux-gnu \

--- a/go1.10/ppc/Dockerfile.tmpl
+++ b/go1.10/ppc/Dockerfile.tmpl
@@ -3,7 +3,7 @@ ARG VERSION
 FROM ${REPOSITORY}/golang-crossbuild:${VERSION}-base
 
 RUN \
-    apt-get update && apt-get install -y --no-install-recommends \
+    apt-get update && apt-get install -y --no-install-recommends --allow-unauthenticated \
         g++-6-powerpc64-linux-gnu \
         gcc-6-powerpc64-linux-gnu \
         crossbuild-essential-ppc64el \

--- a/go1.10/s390x/Dockerfile.tmpl
+++ b/go1.10/s390x/Dockerfile.tmpl
@@ -3,7 +3,7 @@ ARG VERSION
 FROM ${REPOSITORY}/golang-crossbuild:${VERSION}-base
 
 RUN \
-    apt-get update && apt-get install -y --no-install-recommends \
+    apt-get update && apt-get install -y --no-install-recommends --allow-unauthenticated \
         g++-s390x-linux-gnu \
         gcc-s390x-linux-gnu \
     && rm -rf /var/lib/apt/lists/*

--- a/go1.11/arm/Dockerfile.tmpl
+++ b/go1.11/arm/Dockerfile.tmpl
@@ -3,7 +3,7 @@ ARG VERSION
 FROM ${REPOSITORY}/golang-crossbuild:${VERSION}-base
 
 RUN \
-    apt-get update && apt-get install -y --no-install-recommends \
+    apt-get update && apt-get install -y --no-install-recommends --allow-unauthenticated \
         crossbuild-essential-arm64 \
         crossbuild-essential-armel \
         crossbuild-essential-armhf \

--- a/go1.11/base/Dockerfile.tmpl
+++ b/go1.11/base/Dockerfile.tmpl
@@ -9,7 +9,7 @@ COPY sources-debian{{.DEBIAN_VERSION}}.list /etc/apt/sources.list
 RUN \
     apt-get -o Acquire::Check-Valid-Until=false update \
         && apt-get dist-upgrade -y \
-        && apt-get install -y --no-install-recommends \
+        && apt-get install -y --no-install-recommends --allow-unauthenticated \
             build-essential \
             ca-certificates \
             curl \

--- a/go1.11/darwin/Dockerfile.tmpl
+++ b/go1.11/darwin/Dockerfile.tmpl
@@ -3,7 +3,7 @@ ARG VERSION
 FROM ${REPOSITORY}/golang-crossbuild:${VERSION}-base
 
 RUN \
-    apt-get update && apt-get install -y --no-install-recommends \
+    apt-get update && apt-get install -y --no-install-recommends --allow-unauthenticated \
         clang \
         llvm \
     && rm -rf /var/lib/apt/lists/*

--- a/go1.11/main/Dockerfile.tmpl
+++ b/go1.11/main/Dockerfile.tmpl
@@ -6,7 +6,7 @@ FROM ${REPOSITORY}/golang-crossbuild:${VERSION}-base${TAG_EXTENSION}
 RUN \
     dpkg --add-architecture i386 \
     && apt-get -o Acquire::Check-Valid-Until=false update \
-    && apt-get install -y --no-install-recommends \
+    && apt-get install -y --no-install-recommends --allow-unauthenticated \
         clang \
         g++ \
         gcc \

--- a/go1.11/mips/Dockerfile.tmpl
+++ b/go1.11/mips/Dockerfile.tmpl
@@ -3,7 +3,7 @@ ARG VERSION
 FROM ${REPOSITORY}/golang-crossbuild:${VERSION}-base
 
 RUN \
-    apt-get update && apt-get install -y --no-install-recommends \
+    apt-get update && apt-get install -y --no-install-recommends --allow-unauthenticated \
         crossbuild-essential-mipsel \
         gcc-mips-linux-gnu \
         g++-mips-linux-gnu \

--- a/go1.11/ppc/Dockerfile.tmpl
+++ b/go1.11/ppc/Dockerfile.tmpl
@@ -3,7 +3,7 @@ ARG VERSION
 FROM ${REPOSITORY}/golang-crossbuild:${VERSION}-base
 
 RUN \
-    apt-get update && apt-get install -y --no-install-recommends \
+    apt-get update && apt-get install -y --no-install-recommends --allow-unauthenticated \
         g++-6-powerpc64-linux-gnu \
         gcc-6-powerpc64-linux-gnu \
         crossbuild-essential-ppc64el \

--- a/go1.11/s390x/Dockerfile.tmpl
+++ b/go1.11/s390x/Dockerfile.tmpl
@@ -3,7 +3,7 @@ ARG VERSION
 FROM ${REPOSITORY}/golang-crossbuild:${VERSION}-base
 
 RUN \
-    apt-get update && apt-get install -y --no-install-recommends \
+    apt-get update && apt-get install -y --no-install-recommends --allow-unauthenticated \
         g++-s390x-linux-gnu \
         gcc-s390x-linux-gnu \
     && rm -rf /var/lib/apt/lists/*

--- a/go1.12/arm/Dockerfile.tmpl
+++ b/go1.12/arm/Dockerfile.tmpl
@@ -3,7 +3,7 @@ ARG VERSION
 FROM ${REPOSITORY}/golang-crossbuild:${VERSION}-base
 
 RUN \
-    apt-get update && apt-get install -y --no-install-recommends \
+    apt-get update && apt-get install -y --no-install-recommends --allow-unauthenticated \
         crossbuild-essential-arm64 \
         crossbuild-essential-armel \
         crossbuild-essential-armhf \

--- a/go1.12/base/Dockerfile.tmpl
+++ b/go1.12/base/Dockerfile.tmpl
@@ -9,7 +9,7 @@ COPY sources-debian{{.DEBIAN_VERSION}}.list /etc/apt/sources.list
 RUN \
     apt-get -o Acquire::Check-Valid-Until=false update \
         && apt-get dist-upgrade -y \
-        && apt-get install -y --no-install-recommends \
+        && apt-get install -y --no-install-recommends --allow-unauthenticated \
             build-essential \
             ca-certificates \
             curl \

--- a/go1.12/darwin/Dockerfile.tmpl
+++ b/go1.12/darwin/Dockerfile.tmpl
@@ -3,7 +3,7 @@ ARG VERSION
 FROM ${REPOSITORY}/golang-crossbuild:${VERSION}-base
 
 RUN \
-    apt-get update && apt-get install -y --no-install-recommends \
+    apt-get update && apt-get install -y --no-install-recommends --allow-unauthenticated \
         clang \
         llvm \
     && rm -rf /var/lib/apt/lists/*

--- a/go1.12/main/Dockerfile.tmpl
+++ b/go1.12/main/Dockerfile.tmpl
@@ -6,7 +6,7 @@ FROM ${REPOSITORY}/golang-crossbuild:${VERSION}-base${TAG_EXTENSION}
 RUN \
     dpkg --add-architecture i386 \
     && apt-get -o Acquire::Check-Valid-Until=false update \
-    && apt-get install -y --no-install-recommends \
+    && apt-get install -y --no-install-recommends --allow-unauthenticated \
         clang \
         g++ \
         gcc \

--- a/go1.12/mips/Dockerfile.tmpl
+++ b/go1.12/mips/Dockerfile.tmpl
@@ -3,7 +3,7 @@ ARG VERSION
 FROM ${REPOSITORY}/golang-crossbuild:${VERSION}-base
 
 RUN \
-    apt-get update && apt-get install -y --no-install-recommends \
+    apt-get update && apt-get install -y --no-install-recommends --allow-unauthenticated \
         crossbuild-essential-mipsel \
         gcc-mips-linux-gnu \
         g++-mips-linux-gnu \

--- a/go1.12/ppc/Dockerfile.tmpl
+++ b/go1.12/ppc/Dockerfile.tmpl
@@ -3,7 +3,7 @@ ARG VERSION
 FROM ${REPOSITORY}/golang-crossbuild:${VERSION}-base
 
 RUN \
-    apt-get update && apt-get install -y --no-install-recommends \
+    apt-get update && apt-get install -y --no-install-recommends --allow-unauthenticated \
         g++-6-powerpc64-linux-gnu \
         gcc-6-powerpc64-linux-gnu \
         crossbuild-essential-ppc64el \

--- a/go1.12/s390x/Dockerfile.tmpl
+++ b/go1.12/s390x/Dockerfile.tmpl
@@ -3,7 +3,7 @@ ARG VERSION
 FROM ${REPOSITORY}/golang-crossbuild:${VERSION}-base
 
 RUN \
-    apt-get update && apt-get install -y --no-install-recommends \
+    apt-get update && apt-get install -y --no-install-recommends --allow-unauthenticated \
         g++-s390x-linux-gnu \
         gcc-s390x-linux-gnu \
     && rm -rf /var/lib/apt/lists/*

--- a/go1.13/Makefile.common
+++ b/go1.13/Makefile.common
@@ -2,7 +2,7 @@ SELF_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 include $(SELF_DIR)/../Makefile.common
 
 NAME           := golang-crossbuild
-VERSION        := 1.13.10
+VERSION        := 1.13.11
 DEBIAN_VERSION ?= 9
 SUFFIX         := -$(shell basename $(CURDIR))
 TAG_EXTENSION  ?=

--- a/go1.13/arm/Dockerfile.tmpl
+++ b/go1.13/arm/Dockerfile.tmpl
@@ -3,7 +3,7 @@ ARG VERSION
 FROM ${REPOSITORY}/golang-crossbuild:${VERSION}-base
 
 RUN \
-    apt-get update && apt-get install -y --no-install-recommends \
+    apt-get update && apt-get install -y --no-install-recommends --allow-unauthenticated \
         crossbuild-essential-arm64 \
         crossbuild-essential-armel \
         crossbuild-essential-armhf \

--- a/go1.13/base/Dockerfile.tmpl
+++ b/go1.13/base/Dockerfile.tmpl
@@ -21,9 +21,9 @@ RUN \
             bison \
         && rm -rf /var/lib/apt/lists/*
 
-ARG GOLANG_VERSION=1.13.10
+ARG GOLANG_VERSION=1.13.11
 ARG GOLANG_DOWNLOAD_URL=https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
-ARG GOLANG_DOWNLOAD_SHA256=8a4cbc9f2b95d114c38f6cbe94a45372d48c604b707db2057c787398dfbf8e7f
+ARG GOLANG_DOWNLOAD_SHA256=a4d71ca9e02923fa96669a4b5faf78ee8331b18e7209b09dd87fe763b4838ada
 
 RUN curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz \
 	&& echo "$GOLANG_DOWNLOAD_SHA256  golang.tar.gz" | sha256sum -c - \

--- a/go1.13/base/Dockerfile.tmpl
+++ b/go1.13/base/Dockerfile.tmpl
@@ -9,7 +9,7 @@ COPY sources-debian{{.DEBIAN_VERSION}}.list /etc/apt/sources.list
 RUN \
     apt-get -o Acquire::Check-Valid-Until=false update \
         && apt-get dist-upgrade -y \
-        && apt-get install -y --no-install-recommends \
+        && apt-get install -y --no-install-recommends --allow-unauthenticated \
             build-essential \
             ca-certificates \
             curl \

--- a/go1.13/darwin/Dockerfile.tmpl
+++ b/go1.13/darwin/Dockerfile.tmpl
@@ -3,7 +3,7 @@ ARG VERSION
 FROM ${REPOSITORY}/golang-crossbuild:${VERSION}-base
 
 RUN \
-    apt-get update && apt-get install -y --no-install-recommends \
+    apt-get update && apt-get install -y --no-install-recommends --allow-unauthenticated \
         clang \
         llvm \
     && rm -rf /var/lib/apt/lists/*

--- a/go1.13/main/Dockerfile.tmpl
+++ b/go1.13/main/Dockerfile.tmpl
@@ -6,7 +6,7 @@ FROM ${REPOSITORY}/golang-crossbuild:${VERSION}-base${TAG_EXTENSION}
 RUN \
     dpkg --add-architecture i386 \
     && apt-get -o Acquire::Check-Valid-Until=false update \
-    && apt-get install -y --no-install-recommends \
+    && apt-get install -y --no-install-recommends --allow-unauthenticated \
         clang \
         g++ \
         gcc \

--- a/go1.13/mips/Dockerfile.tmpl
+++ b/go1.13/mips/Dockerfile.tmpl
@@ -3,7 +3,7 @@ ARG VERSION
 FROM ${REPOSITORY}/golang-crossbuild:${VERSION}-base
 
 RUN \
-    apt-get update && apt-get install -y --no-install-recommends \
+    apt-get update && apt-get install -y --no-install-recommends --allow-unauthenticated \
         crossbuild-essential-mipsel \
         gcc-mips-linux-gnu \
         g++-mips-linux-gnu \

--- a/go1.13/ppc/Dockerfile.tmpl
+++ b/go1.13/ppc/Dockerfile.tmpl
@@ -3,7 +3,7 @@ ARG VERSION
 FROM ${REPOSITORY}/golang-crossbuild:${VERSION}-base
 
 RUN \
-    apt-get update && apt-get install -y --no-install-recommends \
+    apt-get update && apt-get install -y --no-install-recommends --allow-unauthenticated \
         g++-6-powerpc64-linux-gnu \
         gcc-6-powerpc64-linux-gnu \
         crossbuild-essential-ppc64el \

--- a/go1.13/s390x/Dockerfile.tmpl
+++ b/go1.13/s390x/Dockerfile.tmpl
@@ -3,7 +3,7 @@ ARG VERSION
 FROM ${REPOSITORY}/golang-crossbuild:${VERSION}-base
 
 RUN \
-    apt-get update && apt-get install -y --no-install-recommends \
+    apt-get update && apt-get install -y --no-install-recommends --allow-unauthenticated \
         g++-s390x-linux-gnu \
         gcc-s390x-linux-gnu \
     && rm -rf /var/lib/apt/lists/*

--- a/go1.14/Makefile.common
+++ b/go1.14/Makefile.common
@@ -2,7 +2,7 @@ SELF_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 include $(SELF_DIR)/../Makefile.common
 
 NAME           := golang-crossbuild
-VERSION        := 1.14.2
+VERSION        := 1.14.3
 DEBIAN_VERSION ?= 9
 SUFFIX         := -$(shell basename $(CURDIR))
 TAG_EXTENSION  ?=

--- a/go1.14/arm/Dockerfile.tmpl
+++ b/go1.14/arm/Dockerfile.tmpl
@@ -3,7 +3,7 @@ ARG VERSION
 FROM ${REPOSITORY}/golang-crossbuild:${VERSION}-base
 
 RUN \
-    apt-get update && apt-get install -y --no-install-recommends \
+    apt-get update && apt-get install -y --no-install-recommends --allow-unauthenticated \
         crossbuild-essential-arm64 \
         crossbuild-essential-armel \
         crossbuild-essential-armhf \

--- a/go1.14/base/Dockerfile.tmpl
+++ b/go1.14/base/Dockerfile.tmpl
@@ -21,9 +21,9 @@ RUN \
             bison \
         && rm -rf /var/lib/apt/lists/*
 
-ARG GOLANG_VERSION=1.14.2
+ARG GOLANG_VERSION=1.14.3
 ARG GOLANG_DOWNLOAD_URL=https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
-ARG GOLANG_DOWNLOAD_SHA256=6272d6e940ecb71ea5636ddb5fab3933e087c1356173c61f4a803895e947ebb3
+ARG GOLANG_DOWNLOAD_SHA256=1c39eac4ae95781b066c144c58e45d6859652247f7515f0d2cba7be7d57d2226
 
 RUN curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz \
 	&& echo "$GOLANG_DOWNLOAD_SHA256  golang.tar.gz" | sha256sum -c - \

--- a/go1.14/base/Dockerfile.tmpl
+++ b/go1.14/base/Dockerfile.tmpl
@@ -9,7 +9,7 @@ COPY sources-debian{{.DEBIAN_VERSION}}.list /etc/apt/sources.list
 RUN \
     apt-get -o Acquire::Check-Valid-Until=false update \
         && apt-get dist-upgrade -y \
-        && apt-get install -y --no-install-recommends \
+        && apt-get install -y --no-install-recommends --allow-unauthenticated \
             build-essential \
             ca-certificates \
             curl \

--- a/go1.14/darwin/Dockerfile.tmpl
+++ b/go1.14/darwin/Dockerfile.tmpl
@@ -3,7 +3,7 @@ ARG VERSION
 FROM ${REPOSITORY}/golang-crossbuild:${VERSION}-base
 
 RUN \
-    apt-get update && apt-get install -y --no-install-recommends \
+    apt-get update && apt-get install -y --no-install-recommends --allow-unauthenticated \
         clang \
         llvm \
     && rm -rf /var/lib/apt/lists/*

--- a/go1.14/main/Dockerfile.tmpl
+++ b/go1.14/main/Dockerfile.tmpl
@@ -6,7 +6,7 @@ FROM ${REPOSITORY}/golang-crossbuild:${VERSION}-base${TAG_EXTENSION}
 RUN \
     dpkg --add-architecture i386 \
     && apt-get -o Acquire::Check-Valid-Until=false update \
-    && apt-get install -y --no-install-recommends \
+    && apt-get install -y --no-install-recommends --allow-unauthenticated \
         clang \
         g++ \
         gcc \

--- a/go1.14/mips/Dockerfile.tmpl
+++ b/go1.14/mips/Dockerfile.tmpl
@@ -3,7 +3,7 @@ ARG VERSION
 FROM ${REPOSITORY}/golang-crossbuild:${VERSION}-base
 
 RUN \
-    apt-get update && apt-get install -y --no-install-recommends \
+    apt-get update && apt-get install -y --no-install-recommends --allow-unauthenticated \
         crossbuild-essential-mipsel \
         gcc-mips-linux-gnu \
         g++-mips-linux-gnu \

--- a/go1.14/ppc/Dockerfile.tmpl
+++ b/go1.14/ppc/Dockerfile.tmpl
@@ -3,7 +3,7 @@ ARG VERSION
 FROM ${REPOSITORY}/golang-crossbuild:${VERSION}-base
 
 RUN \
-    apt-get update && apt-get install -y --no-install-recommends \
+    apt-get update && apt-get install -y --no-install-recommends --allow-unauthenticated \
         g++-6-powerpc64-linux-gnu \
         gcc-6-powerpc64-linux-gnu \
         crossbuild-essential-ppc64el \

--- a/go1.14/s390x/Dockerfile.tmpl
+++ b/go1.14/s390x/Dockerfile.tmpl
@@ -3,7 +3,7 @@ ARG VERSION
 FROM ${REPOSITORY}/golang-crossbuild:${VERSION}-base
 
 RUN \
-    apt-get update && apt-get install -y --no-install-recommends \
+    apt-get update && apt-get install -y --no-install-recommends --allow-unauthenticated \
         g++-s390x-linux-gnu \
         gcc-s390x-linux-gnu \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
go1.14.3 (released 2020/05/14) includes fixes to cgo, the compiler, the runtime, and the go/doc and math/big packages.

go1.13.11 (released 2020/05/14) includes fixes to the compiler.