### PR TITLE
[CI]: CI pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@
 @Library('apm@current') _
 
 pipeline {
-  agent { label 'linux && immutable' }
+  agent { label 'ubuntu && immutable' }
   environment {
     REPO = 'golang-crossbuild'
     BASE_DIR = "src/github.com/elastic/${env.REPO}"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,17 +49,18 @@ pipeline {
       }
     }
     stage('Staging') {
+      environment {
+        REPOSITORY = "${env.STAGING_IMAGE}"
+      }
       steps {
         withGithubNotify(context: 'Staging') {
           withGoEnv(){
             dir(BASE_DIR){
               dockerLogin(secret: "${DOCKER_REGISTRY_SECRET}", registry: "${REGISTRY}")
-              withEnv( [ "REPOSITORY=${env.STAGING_IMAGE}" ] ) {
-                // It will use the already cached docker images that were created in the
-                // Build stage. But it's required to retag them with the staging repo.
-                sh 'make build'
-                sh(label: "push docker image to ${env.REPOSITORY}", script: 'make push')
-              }
+              // It will use the already cached docker images that were created in the
+              // Build stage. But it's required to retag them with the staging repo.
+              sh 'make build'
+              sh(label: "push docker image to ${env.REPOSITORY}", script: 'make push')
             }
           }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,8 +50,12 @@ pipeline {
         withGithubNotify(context: 'Staging') {
           dir(BASE_DIR){
             dockerLogin(secret: "${DOCKER_REGISTRY_SECRET}", registry: "${REGISTRY}")
-            sh(label: "push docker image to ${env.STAGING_IMAGE}/${env.REPO}",
-               script: "REPOSITORY=${env.STAGING_IMAGE}/${env.REPO} VERSION=${env.BRANCH_NAME} make push")
+            withEnv( [ "REPOSITORY=${env.STAGING_IMAGE}" ] ) {
+              // It will use the already cached docker images that were created in the
+              // Build stage. But it's required to retag them with the staging repo.
+              sh 'make build'
+              sh(label: "push docker image to ${env.REPOSITORY}", script: 'make push')
+            }
           }
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,7 @@ pipeline {
     NOTIFY_TO = credentials('notify-to')
     PIPELINE_LOG_LEVEL = 'INFO'
     HOME = "${env.WORKSPACE}"
-    DOCKER_REGISTRY_SECRET = 'secret/apm-team/ci/docker-registry/prod'
+    DOCKER_REGISTRY_SECRET = 'secret/observability-team/ci/docker-registry/prod'
     REGISTRY = 'docker.elastic.co'
     STAGING_IMAGE = "${env.REGISTRY}/observability-ci"
     GO_VERSION = '1.14.2'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -62,9 +62,7 @@ pipeline {
     }
     stage('Release') {
       when {
-        anyOf {
-          tag pattern: 'v\\d+\\.\\d+.*', comparator: 'REGEXP'
-        }
+        branch 'master'
       }
       stages {
         stage('Publish') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,89 @@
+
+@Library('apm@current') _
+
+pipeline {
+  agent { label 'linux && immutable' }
+  environment {
+    REPO = 'golang-crossbuild'
+    BASE_DIR = "src/github.com/elastic/${env.REPO}"
+    NOTIFY_TO = credentials('notify-to')
+    PIPELINE_LOG_LEVEL = 'INFO'
+    PATH = "${env.PATH}:${env.WORKSPACE}/bin"
+    HOME = "${env.WORKSPACE}"
+    DOCKER_REGISTRY_SECRET = 'secret/apm-team/ci/docker-registry/prod'
+    REGISTRY = 'docker.elastic.co'
+    STAGING_IMAGE = "${env.REGISTRY}/observability-ci"
+  }
+  options {
+    timeout(time: 1, unit: 'HOURS')
+    buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '20', daysToKeepStr: '30'))
+    timestamps()
+    ansiColor('xterm')
+    disableResume()
+    durabilityHint('PERFORMANCE_OPTIMIZED')
+    rateLimitBuilds(throttle: [count: 60, durationName: 'hour', userBoost: true])
+    quietPeriod(10)
+  }
+  triggers {
+    issueCommentTrigger('(?i).*jenkins\\W+run\\W+(?:the\\W+)?tests(?:\\W+please)?.*')
+  }
+  stages {
+    stage('Checkout') {
+      steps {
+        deleteDir()
+        gitCheckout(basedir: BASE_DIR)
+        stash allowEmpty: true, name: 'source', useDefaultExcludes: false
+      }
+    }
+    stage('Build') {
+      steps {
+        withGithubNotify(context: 'Build') {
+          deleteDir()
+          unstash 'source'
+          dir(BASE_DIR){
+            sh 'make build'
+          }
+        }
+      }
+    }
+    stage('Staging') {
+      steps {
+        withGithubNotify(context: 'Staging') {
+          deleteDir()
+          unstash 'source'
+          dir(BASE_DIR){
+            dockerLogin(secret: "${DOCKER_REGISTRY_SECRET}", registry: "${REGISTRY}")
+            sh(label: "push docker image to ${env.STAGING_IMAGE}/${env.REPO_NAME}",
+               script: "REPOSITORY=${env.STAGING_IMAGE}/${env.REPO_NAME} VERSION==${env.BRANCH_NAME} make push")
+          }
+        }
+      }
+    }
+    stage('Release') {
+      when {
+        anyOf {
+          tag pattern: 'v\\d+\\.\\d+.*', comparator: 'REGEXP'
+        }
+      }
+      stages {
+        stage('Publish') {
+          steps {
+            withGithubNotify(context: 'Publish') {
+              deleteDir()
+              unstash 'source'
+              dir(BASE_DIR){
+                dockerLogin(secret: "${DOCKER_REGISTRY_SECRET}", registry: "${REGISTRY}")
+                sh 'make push'
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  post {
+    always {
+      notifyBuildResult()
+    }
+  }
+}

--- a/Makefile.common
+++ b/Makefile.common
@@ -1,4 +1,4 @@
-REPOSITORY    := docker.elastic.co/beats-dev
+REPOSITORY    ?= docker.elastic.co/beats-dev
 VCS_REF       := $(shell git rev-parse HEAD)
 VCS_URL       := https://github.com/elastic/golang-crossbuild
 BUILD_DATE    := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")

--- a/Makefile.common
+++ b/Makefile.common
@@ -7,7 +7,6 @@ BUILD_DATE    := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 # Requires login at https://docker.elastic.co:7000/.
 push:
 	echo ">> Pushing $(REPOSITORY)/$(NAME):$(VERSION)$(SUFFIX)$(TAG_EXTENSION)"
-	@docker tag "$(REPOSITORY)/$(NAME):$(VERSION)$(SUFFIX)$(TAG_EXTENSION)" "push.$(REPOSITORY)/$(NAME):$(VERSION)$(SUFFIX)$(TAG_EXTENSION)"
-	@docker push "push.$(REPOSITORY)/$(NAME):$(VERSION)$(SUFFIX)$(TAG_EXTENSION)"
+	@docker push "$(REPOSITORY)/$(NAME):$(VERSION)$(SUFFIX)$(TAG_EXTENSION)"
 
 .PHONY: push

--- a/README.md
+++ b/README.md
@@ -53,5 +53,4 @@ GOARM, PLATFORM_ID, CC, and CXX.
 1. Commit the changes. `git add -u && git commit -m 'Update to Go 1.x.y'`.
 1. Build the images from the project's root with `make`.
 1. Get a logon token for the container registry by visiting <https://docker.elastic.co:7000>.
-   In the provided login command change `docker.elastic.co` to `push.docker.elastic.co`.
 1. Publish the images with `make push`.

--- a/fpm/Makefile
+++ b/fpm/Makefile
@@ -1,7 +1,7 @@
 include ../Makefile.common
 
 NAME    := fpm
-VERSION ?= 1.11.0
+VERSION := 1.11.0
 
 build:
 	@echo ">> Building $(REPOSITORY)/$(NAME):$(VERSION)$(SUFFIX)"

--- a/fpm/Makefile
+++ b/fpm/Makefile
@@ -1,7 +1,7 @@
 include ../Makefile.common
 
 NAME    := fpm
-VERSION := 1.11.0
+VERSION ?= 1.11.0
 
 build:
 	@echo ">> Building $(REPOSITORY)/$(NAME):$(VERSION)$(SUFFIX)"


### PR DESCRIPTION
### What

Enable CI pipeline to build and push the docker images.

The push event works for:
- everything (branches, tags, PRs) and will push them in https://docker.elastic.co:7000/observability-ci/golang-crossbuild:<VERSION><SUFFIX> 
- on master based to the default location set in the Makefile.

### Tasks

- [x] Create JJBB definition (see https://github.com/elastic/beats/pull/19162)

### Test

- `REPOSITORY=docker.elastic.co/observability-ci make build`

```
$ docker images | grep observability-ci            
docker.elastic.co/observability-ci/fpm                      1.11.0                 1fbf2b9b5555        2 minutes ago       416MB
docker.elastic.co/observability-ci/golang-crossbuild        1.14.4-main-debian8    51fbb901cd8a        2 minutes ago       1.39GB
docker.elastic.co/observability-ci/golang-crossbuild        1.14.4-main-debian7    3c5321b6f233        2 minutes ago       1.01GB
docker.elastic.co/observability-ci/golang-crossbuild        1.14.4-s390x           8064f3af14bd        2 minutes ago       807MB
docker.elastic.co/observability-ci/golang-crossbuild        1.14.4-ppc             57b58c057ff9        2 minutes ago       994MB
...
```

- `REPOSITORY=docker.elastic.co/observability-ci make push`

```
echo ">> Pushing docker.elastic.co/observability-ci/golang-crossbuild:1.10.8-base"
>> Pushing docker.elastic.co/observability-ci/golang-crossbuild:1.10.8-base
The push refers to repository [docker.elastic.co/observability-ci/golang-crossbuild]
772921e6e3a7: Preparing 
041e855fb031: Preparing 
e142d45a5747: Preparing 
...
```