### PR TITLE
fix: user the same version tag than Go in Beats

### DIFF
--- a/go1.13/Makefile.common
+++ b/go1.13/Makefile.common
@@ -2,7 +2,7 @@ SELF_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 include $(SELF_DIR)/../Makefile.common
 
 NAME           := golang-crossbuild
-VERSION        := 1.13.12
+VERSION        := 1.13.10
 DEBIAN_VERSION ?= 9
 SUFFIX         := -$(shell basename $(CURDIR))
 TAG_EXTENSION  ?=


### PR DESCRIPTION
set the tag to the same Go version we use in Beats