### PR TITLE
Support docker buildx multiplatform

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -84,6 +84,7 @@ pipeline {
 
 def buildAndPushImages(){
   dockerLogin(secret: "${env.DOCKER_REGISTRY_SECRET}", registry: "${env.REGISTRY}")
+  sh 'docker buildx create --use'
   withGoEnv(){
     dir("${env.BASE_DIR}"){
       sh "make -C ${GO_FOLDER} -f ${MAKEFILE} build"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@
 @Library('apm@current') _
 
 pipeline {
-  agent { label 'ubuntu-18 && immutable && docker-buildx' }
+  agent { label 'ubuntu-20 && immutable' }
   environment {
     REPO = 'golang-crossbuild'
     BASE_DIR = "src/github.com/elastic/${env.REPO}"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@
 @Library('apm@current') _
 
 pipeline {
-  agent { label 'ubuntu-20 && immutable && docker-buildx' }
+  agent { label 'ubuntu-18 && immutable && docker-buildx' }
   environment {
     REPO = 'golang-crossbuild'
     BASE_DIR = "src/github.com/elastic/${env.REPO}"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@
 @Library('apm@current') _
 
 pipeline {
-  agent { label 'ubuntu-20 && immutable' }
+  agent { label 'ubuntu-20 && immutable && docker-buildx' }
   environment {
     REPO = 'golang-crossbuild'
     BASE_DIR = "src/github.com/elastic/${env.REPO}"
@@ -61,6 +61,9 @@ pipeline {
           stage('Staging') {
             environment {
               REPOSITORY = "${env.STAGING_IMAGE}"
+            }
+            when {
+              environment(name: 'GO_FOLDER', value: 'go1.13')
             }
             steps {
               withGithubNotify(context: "Staging ${GO_FOLDER} ${MAKEFILE}") {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,6 +50,9 @@ pipeline {
         }
         stages {
           stage('Build') {
+            environment {
+              REPOSITORY = "${env.STAGING_IMAGE}"
+            }
             steps {
               withGithubNotify(context: "Build ${GO_FOLDER} ${MAKEFILE}") {
                 deleteDir()

--- a/go1.14/Makefile.common
+++ b/go1.14/Makefile.common
@@ -12,7 +12,10 @@ export DEBIAN_VERSION TAG_EXTENSION
 build:
 	@echo ">> Building $(REPOSITORY)/$(NAME):$(VERSION)$(SUFFIX)$(TAG_EXTENSION)"
 	@go run $(SELF_DIR)/../template.go -t Dockerfile.tmpl -o Dockerfile
-	@docker build -t "$(REPOSITORY)/$(NAME):$(VERSION)$(SUFFIX)$(TAG_EXTENSION)" \
+	@docker buildx build \
+	--progress=plain \
+	--platform linux/amd64,linux/arm64 \
+	-t "$(REPOSITORY)/$(NAME):$(VERSION)$(SUFFIX)$(TAG_EXTENSION)" \
 	--build-arg REPOSITORY=$(REPOSITORY) \
 	--build-arg VERSION=$(VERSION) \
 	--build-arg DEBIAN_VERSION=$(DEBIAN_VERSION) \
@@ -21,6 +24,7 @@ build:
 	--build-arg VCS_REF="$(VCS_REF)" \
 	--build-arg VCS_URL="$(VCS_URL)" \
 	--build-arg BUILD_DATE="$(BUILD_DATE)" \
+	--push \
 	.
 
 .PHONY: build

--- a/go1.15/Makefile.common
+++ b/go1.15/Makefile.common
@@ -12,7 +12,10 @@ export DEBIAN_VERSION TAG_EXTENSION
 build:
 	@echo ">> Building $(REPOSITORY)/$(NAME):$(VERSION)$(SUFFIX)$(TAG_EXTENSION)"
 	@go run $(SELF_DIR)/../template.go -t Dockerfile.tmpl -o Dockerfile
-	@docker build -t "$(REPOSITORY)/$(NAME):$(VERSION)$(SUFFIX)$(TAG_EXTENSION)" \
+	@docker buildx build \
+	--progress=plain \
+	--platform linux/amd64,linux/arm64 \
+	-t "$(REPOSITORY)/$(NAME):$(VERSION)$(SUFFIX)$(TAG_EXTENSION)" \
 	--build-arg REPOSITORY=$(REPOSITORY) \
 	--build-arg VERSION=$(VERSION) \
 	--build-arg DEBIAN_VERSION=$(DEBIAN_VERSION) \
@@ -21,6 +24,7 @@ build:
 	--build-arg VCS_REF="$(VCS_REF)" \
 	--build-arg VCS_URL="$(VCS_URL)" \
 	--build-arg BUILD_DATE="$(BUILD_DATE)" \
+	--push \
 	.
 
 .PHONY: build


### PR DESCRIPTION
### What

Use `docker-buildx` agents to build a multiplaform docker images for go1.14 and go1.15

Staging won't be needed anymore since `docker buildx --push` supports that feature now therefore no push explicitly but delegated to the makefile instead.