### PR TITLE
feta: precompile libpcap

### DIFF
--- a/go1.16/arm/Dockerfile.tmpl
+++ b/go1.16/arm/Dockerfile.tmpl
@@ -58,6 +58,10 @@ RUN cd / \
   && file helloWorld | cut -d "," -f 2 | grep -c 'ARM aarch64'\
   && rm helloWorld.c helloWorld
 
+RUN cd /libpcap/libpcap-1.8.1 \
+	&& ./configure --enable-usb=no --enable-bluetooth=no --enable-dbus=no --host=aarch64-unknown-linux-gnu --with-pcap=linux \
+	&& make
+
 # Build-time metadata as defined at http://label-schema.org.
 ARG BUILD_DATE
 ARG IMAGE

--- a/go1.16/armel/Dockerfile.tmpl
+++ b/go1.16/armel/Dockerfile.tmpl
@@ -58,6 +58,10 @@ RUN cd / \
   && file helloWorld | cut -d "," -f 3 | grep -c 'EABI'\
   && rm helloWorld.c helloWorld
 
+RUN cd /libpcap/libpcap-1.8.1 \
+	&& ./configure --enable-usb=no --enable-bluetooth=no --enable-dbus=no --host=arm-linux-gnueabi --with-pcap=linux \
+	&& make
+
 # Build-time metadata as defined at http://label-schema.org.
 ARG BUILD_DATE
 ARG IMAGE

--- a/go1.16/armhf/Dockerfile.tmpl
+++ b/go1.16/armhf/Dockerfile.tmpl
@@ -58,6 +58,10 @@ RUN cd / \
   && file helloWorld | cut -d "," -f 5 | grep -c 'armhf.so'\
   && rm helloWorld.c helloWorld
 
+RUN cd /libpcap/libpcap-1.8.1 \
+	&& ./configure --enable-usb=no --enable-bluetooth=no --enable-dbus=no --host=arm-linux-gnueabihf --with-pcap=linux \
+	&& make
+
 # Build-time metadata as defined at http://label-schema.org.
 ARG BUILD_DATE
 ARG IMAGE

--- a/go1.16/base-arm/Dockerfile.tmpl
+++ b/go1.16/base-arm/Dockerfile.tmpl
@@ -63,6 +63,13 @@ RUN go mod init github.com/elastic/golang-crossbuild-$GOLANG_VERSION-arm \
     && go build -o /crossbuild /entrypoint.go \
     && rm -rf /go/* /root/.cache/* /entrypoint.go
 
+RUN curl -sSLO https://s3.amazonaws.com/beats-files/deps/libpcap-1.8.1.tar.gz \
+  && mkdir /libpcap \
+	&& tar -xzf libpcap-1.8.1.tar.gz -C /libpcap \
+  && cd /libpcap/libpcap-1.8.1 \
+  && ./configure --enable-usb=no --enable-bluetooth=no --enable-dbus=no --host=aarch64-unknown-linux-gnu --with-pcap=linux \
+  && make
+
 ENV GOLANG_CROSSBUILD=1
 VOLUME      /app
 WORKDIR     /app

--- a/go1.16/base/Dockerfile.tmpl
+++ b/go1.16/base/Dockerfile.tmpl
@@ -47,8 +47,11 @@ RUN go mod init github.com/elastic/golang-crossbuild-$GOLANG_VERSION \
     && rm -rf /go/* /root/.cache/* /entrypoint.go
 
 RUN curl -sSLO https://s3.amazonaws.com/beats-files/deps/libpcap-1.8.1.tar.gz \
+  && echo "673dbc69fdc3f5a86fb5759ab19899039a8e5e6c631749e48dcd9c6f0c83541e  libpcap-1.8.1.tar.gz" | sha256sum -c - \
   && mkdir /libpcap \
-	&& tar -xzf libpcap-1.8.1.tar.gz -C /libpcap
+	&& tar -xzf libpcap-1.8.1.tar.gz -C /libpcap \
+  && rm libpcap-1.8.1.tar.gz
+
 
 ENV GOLANG_CROSSBUILD=1
 VOLUME      /app

--- a/go1.16/base/Dockerfile.tmpl
+++ b/go1.16/base/Dockerfile.tmpl
@@ -46,6 +46,10 @@ RUN go mod init github.com/elastic/golang-crossbuild-$GOLANG_VERSION \
     && go build -o /crossbuild /entrypoint.go \
     && rm -rf /go/* /root/.cache/* /entrypoint.go
 
+RUN curl -sSLO https://s3.amazonaws.com/beats-files/deps/libpcap-1.8.1.tar.gz \
+  && mkdir /libpcap \
+	&& tar -xzf libpcap-1.8.1.tar.gz -C /libpcap
+
 ENV GOLANG_CROSSBUILD=1
 VOLUME      /app
 WORKDIR     /app

--- a/go1.16/main/Dockerfile.tmpl
+++ b/go1.16/main/Dockerfile.tmpl
@@ -47,11 +47,15 @@ RUN curl -sSLO https://www.winpcap.org/install/bin/WpdPack_4_1_2.zip \
   && unzip WpdPack_4_1_2.zip -d /libpcap/win \
   && rm WpdPack_4_1_2.zip \
   && cd /libpcap/win/WpdPack \
+  && curl -sSLO https://raw.githubusercontent.com/elastic/beats/master/packetbeat/lib/windows-64/wpcap.dll \
+  && echo "0948518b229fb502b9c063966fc3afafbb749241a1c184f6eb7d532e00bce1d8  wpcap.dll" | sha256sum -c - \
+  && gendef wpcap.dll \
   && x86_64-w64-mingw32-dlltool \
     --as-flags=--64 \
     -m i386:x86-64 \
     -k \
-    --output-lib /libpcap/win/WpdPack/Lib/x64/libwpcap.a
+    --output-lib /libpcap/win/WpdPack/Lib/x64/libwpcap.a \
+    --input-def /libpcap/win/WpdPack/wpcap.def
 
 # Build-time metadata as defined at http://label-schema.org.
 ARG BUILD_DATE

--- a/go1.16/main/Dockerfile.tmpl
+++ b/go1.16/main/Dockerfile.tmpl
@@ -43,7 +43,9 @@ RUN cd /libpcap/libpcap-1.8.1 \
 
 RUN curl -sSLO https://www.winpcap.org/install/bin/WpdPack_4_1_2.zip \
   && mkdir -p /libpcap/win \
+  && echo "ea799cf2f26e4afb1892938070fd2b1ca37ce5cf75fec4349247df12b784edbd  WpdPack_4_1_2.zip" | sha256sum -c - \
   && unzip WpdPack_4_1_2.zip -d /libpcap/win \
+  && rm WpdPack_4_1_2.zip \
   && cd /libpcap/win/WpdPack \
   && x86_64-w64-mingw32-dlltool \
     --as-flags=--64 \

--- a/go1.16/main/Dockerfile.tmpl
+++ b/go1.16/main/Dockerfile.tmpl
@@ -32,16 +32,14 @@ RUN cd / \
   && rm helloWorld.c helloWorld
 
 RUN cd /libpcap/libpcap-1.8.1 \
-  && mkdir -p /libpcap/libpcap-1.8.1-i386 \
-  && mkdir -p /libpcap/libpcap-1.8.1-amd64 \
+  && cp -R /libpcap/libpcap-1.8.1 /libpcap/libpcap-1.8.1-i386 \
+  && cp -R /libpcap/libpcap-1.8.1 /libpcap/libpcap-1.8.1-amd64 \
+  && cd /libpcap/libpcap-1.8.1-i386 \
 	&& CFLAGS="-m32" LDFLAGS="-m32" ./configure --enable-usb=no --enable-bluetooth=no --enable-dbus=no \
 	&& make \
-  && cp libpcap.* ../libpcap/libpcap-1.8.1-i386 \
-  && make clean \
+  && cd /libpcap/libpcap-1.8.1-amd64 \
   && ./configure --enable-usb=no --enable-bluetooth=no --enable-dbus=no \
   && make \
-  && cp libpcap.* ../libpcap/libpcap-1.8.1-amd64/ \
-  && make clean \
 
 RUN curl -sSLO https://www.winpcap.org/install/bin/WpdPack_4_1_2.zip \
   && mkdir -p /libpcap/win \

--- a/go1.16/main/Dockerfile.tmpl
+++ b/go1.16/main/Dockerfile.tmpl
@@ -39,7 +39,7 @@ RUN cd /libpcap/libpcap-1.8.1 \
 	&& make \
   && cd /libpcap/libpcap-1.8.1-amd64 \
   && ./configure --enable-usb=no --enable-bluetooth=no --enable-dbus=no \
-  && make \
+  && make
 
 RUN curl -sSLO https://www.winpcap.org/install/bin/WpdPack_4_1_2.zip \
   && mkdir -p /libpcap/win \

--- a/go1.16/main/Dockerfile.tmpl
+++ b/go1.16/main/Dockerfile.tmpl
@@ -18,6 +18,7 @@ RUN \
         mingw-w64-tools \
         patch \
         xz-utils \
+        unzip \
     && rm -rf /var/lib/apt/lists/*
 
 COPY rootfs /
@@ -29,6 +30,28 @@ RUN cd / \
   && readelf -h helloWorld \
   && file helloWorld | cut -d "," -f 2 | grep -c 'x86-64' \
   && rm helloWorld.c helloWorld
+
+RUN cd /libpcap/libpcap-1.8.1 \
+  && mkdir -p /libpcap/libpcap-1.8.1-i386 \
+  && mkdir -p /libpcap/libpcap-1.8.1-amd64 \
+	&& CFLAGS="-m32" LDFLAGS="-m32" ./configure --enable-usb=no --enable-bluetooth=no --enable-dbus=no \
+	&& make \
+  && cp libpcap.* ../libpcap/libpcap-1.8.1-i386 \
+  && make clean \
+  && ./configure --enable-usb=no --enable-bluetooth=no --enable-dbus=no \
+  && make \
+  && cp libpcap.* ../libpcap/libpcap-1.8.1-amd64/ \
+  && make clean \
+
+RUN curl -sSLO https://www.winpcap.org/install/bin/WpdPack_4_1_2.zip \
+  && mkdir -p /libpcap/win \
+  && unzip WpdPack_4_1_2.zip -d /libpcap/win \
+  && cd /libpcap/win/WpdPack \
+  && x86_64-w64-mingw32-dlltool \
+    --as-flags=--64 \
+    -m i386:x86-64 \
+    -k \
+    --output-lib /libpcap/win/WpdPack/Lib/x64/libwpcap.a
 
 # Build-time metadata as defined at http://label-schema.org.
 ARG BUILD_DATE

--- a/go1.16/mips/Dockerfile.tmpl
+++ b/go1.16/mips/Dockerfile.tmpl
@@ -74,6 +74,16 @@ RUN cd / \
   && readelf -h helloWorld | grep -c "big endian" \
   && rm helloWorld.c helloWorld
 
+RUN cd /libpcap/libpcap-1.8.1 \
+  && cp -R /libpcap/libpcap-1.8.1 /libpcap/libpcap-1.8.1-mips64 \
+  && cp -R /libpcap/libpcap-1.8.1 /libpcap/libpcap-1.8.1-mips64el \
+  && cd /libpcap/libpcap-1.8.1-mips64 \
+	&& CC=mips64-linux-gnuabi64-gcc ./configure --enable-usb=no --enable-bluetooth=no --enable-dbus=no --host=mips64-unknown-linux-gnu --with-pcap=linux \
+	&& make \
+  && cd /libpcap/libpcap-1.8.1-mips64el \
+	&& CC=mips64el-linux-gnuabi64-gcc ./configure --enable-usb=no --enable-bluetooth=no --enable-dbus=no --host=mips64el-unknown-linux-gnu --with-pcap=linux \
+	&& make
+
 # Build-time metadata as defined at http://label-schema.org.
 ARG BUILD_DATE
 ARG IMAGE

--- a/go1.16/mips32/Dockerfile.tmpl
+++ b/go1.16/mips32/Dockerfile.tmpl
@@ -62,15 +62,25 @@ RUN cd / \
   && readelf -h helloWorld | grep -c "big endian" \
   && rm helloWorld
 
-  # Basic test
-  RUN cd / \
-    && mipsel-linux-gnu-gcc helloWorld.c -o helloWorld \
-    && file helloWorld \
-    && readelf -h helloWorld \
-    && readelf -h helloWorld | grep -c 'MIPS R3000' \
-    && readelf -h helloWorld | grep -c 'ELF32' \
-    && readelf -h helloWorld | grep -c "little endian" \
-    && rm helloWorld.c helloWorld
+# Basic test
+RUN cd / \
+  && mipsel-linux-gnu-gcc helloWorld.c -o helloWorld \
+  && file helloWorld \
+  && readelf -h helloWorld \
+  && readelf -h helloWorld | grep -c 'MIPS R3000' \
+  && readelf -h helloWorld | grep -c 'ELF32' \
+  && readelf -h helloWorld | grep -c "little endian" \
+  && rm helloWorld.c helloWorld
+
+RUN cd /libpcap/libpcap-1.8.1 \
+  && cp -R /libpcap/libpcap-1.8.1 /libpcap/libpcap-1.8.1-mips \
+  && cp -R /libpcap/libpcap-1.8.1 /libpcap/libpcap-1.8.1-mipsel \
+  && cd /libpcap/libpcap-1.8.1-mips \
+	&& CC=mips-linux-gnu-gcc ./configure --enable-usb=no --enable-bluetooth=no --enable-dbus=no --host=mips-unknown-linux-gnu --with-pcap=linux \
+	&& make \
+  && cd /libpcap/libpcap-1.8.1-mipsel \
+	&& CC=mipsel-linux-gnu-gcc ./configure --enable-usb=no --enable-bluetooth=no --enable-dbus=no --host=mipsel-unknown-linux-gnu --with-pcap=linux \
+	&& make
 
 # Build-time metadata as defined at http://label-schema.org.
 ARG BUILD_DATE

--- a/go1.16/ppc/Dockerfile.tmpl
+++ b/go1.16/ppc/Dockerfile.tmpl
@@ -58,6 +58,16 @@ RUN cd / \
   && readelf -h helloWorld | grep -c "little endian" \
   && rm helloWorld.c helloWorld
 
+  RUN cd /libpcap/libpcap-1.8.1 \
+    && cp -R /libpcap/libpcap-1.8.1 /libpcap/libpcap-1.8.1-ppc64 \
+    && cp -R /libpcap/libpcap-1.8.1 /libpcap/libpcap-1.8.1-ppc64el \
+    && cd /libpcap/libpcap-1.8.1-ppc64 \
+  	&& ./configure --enable-usb=no --enable-bluetooth=no --enable-dbus=no --host=ppc64-unknown-linux-gnu --with-pcap=linux \
+  	&& make \
+    && cd /libpcap/libpcap-1.8.1-ppc64el \
+  	&& ./configure --enable-usb=no --enable-bluetooth=no --enable-dbus=no --host=ppc64el-unknown-linux-gnu --with-pcap=linux \
+  	&& make
+
 # Build-time metadata as defined at http://label-schema.org.
 ARG BUILD_DATE
 ARG IMAGE

--- a/go1.16/ppc/Dockerfile.tmpl
+++ b/go1.16/ppc/Dockerfile.tmpl
@@ -62,10 +62,10 @@ RUN cd /libpcap/libpcap-1.8.1 \
   && cp -R /libpcap/libpcap-1.8.1 /libpcap/libpcap-1.8.1-ppc64 \
   && cp -R /libpcap/libpcap-1.8.1 /libpcap/libpcap-1.8.1-ppc64el \
   && cd /libpcap/libpcap-1.8.1-ppc64 \
-	&& ./configure --enable-usb=no --enable-bluetooth=no --enable-dbus=no --host=ppc64-unknown-linux-gnu --with-pcap=linux \
+	&& CC=powerpc64-linux-gnu-gcc ./configure --enable-usb=no --enable-bluetooth=no --enable-dbus=no --host=ppc64-unknown-linux-gnu --with-pcap=linux \
 	&& make \
   && cd /libpcap/libpcap-1.8.1-ppc64el \
-	&& ./configure --enable-usb=no --enable-bluetooth=no --enable-dbus=no --host=ppc64el-unknown-linux-gnu --with-pcap=linux \
+	&& CC=powerpc64le-linux-gnu-gcc ./configure --enable-usb=no --enable-bluetooth=no --enable-dbus=no --host=ppc64el-unknown-linux-gnu --with-pcap=linux \
 	&& make
 
 # Build-time metadata as defined at http://label-schema.org.

--- a/go1.16/ppc/Dockerfile.tmpl
+++ b/go1.16/ppc/Dockerfile.tmpl
@@ -58,15 +58,15 @@ RUN cd / \
   && readelf -h helloWorld | grep -c "little endian" \
   && rm helloWorld.c helloWorld
 
-  RUN cd /libpcap/libpcap-1.8.1 \
-    && cp -R /libpcap/libpcap-1.8.1 /libpcap/libpcap-1.8.1-ppc64 \
-    && cp -R /libpcap/libpcap-1.8.1 /libpcap/libpcap-1.8.1-ppc64el \
-    && cd /libpcap/libpcap-1.8.1-ppc64 \
-  	&& ./configure --enable-usb=no --enable-bluetooth=no --enable-dbus=no --host=ppc64-unknown-linux-gnu --with-pcap=linux \
-  	&& make \
-    && cd /libpcap/libpcap-1.8.1-ppc64el \
-  	&& ./configure --enable-usb=no --enable-bluetooth=no --enable-dbus=no --host=ppc64el-unknown-linux-gnu --with-pcap=linux \
-  	&& make
+RUN cd /libpcap/libpcap-1.8.1 \
+  && cp -R /libpcap/libpcap-1.8.1 /libpcap/libpcap-1.8.1-ppc64 \
+  && cp -R /libpcap/libpcap-1.8.1 /libpcap/libpcap-1.8.1-ppc64el \
+  && cd /libpcap/libpcap-1.8.1-ppc64 \
+	&& ./configure --enable-usb=no --enable-bluetooth=no --enable-dbus=no --host=ppc64-unknown-linux-gnu --with-pcap=linux \
+	&& make \
+  && cd /libpcap/libpcap-1.8.1-ppc64el \
+	&& ./configure --enable-usb=no --enable-bluetooth=no --enable-dbus=no --host=ppc64el-unknown-linux-gnu --with-pcap=linux \
+	&& make
 
 # Build-time metadata as defined at http://label-schema.org.
 ARG BUILD_DATE

--- a/go1.16/ppc/rootfs/compilers.yaml
+++ b/go1.16/ppc/rootfs/compilers.yaml
@@ -2,8 +2,8 @@
 
 linux:
   ppc64:
-    CC:  powerpc64-linux-gnu-gcc-6
-    CXX: powerpc64-linux-gnu-g++-6
+    CC:  powerpc64-linux-gnu-gcc
+    CXX: powerpc64-linux-gnu-g++
   ppc64le:
     CC:  powerpc64le-linux-gnu-gcc
     CXX: powerpc64le-linux-gnu-g++

--- a/go1.16/s390x/Dockerfile.tmpl
+++ b/go1.16/s390x/Dockerfile.tmpl
@@ -58,7 +58,7 @@ RUN cd / \
   && rm helloWorld.c helloWorld
 
 RUN cd /libpcap/libpcap-1.8.1 \
-	&& ./configure --enable-usb=no --enable-bluetooth=no --enable-dbus=no --host=s390x-ibm-linux-gnu --with-pcap=linux \
+	&& CC=s390x-linux-gnu-gcc ./configure --enable-usb=no --enable-bluetooth=no --enable-dbus=no --host=s390x-ibm-linux-gnu --with-pcap=linux \
 	&& make
 
 # Build-time metadata as defined at http://label-schema.org.

--- a/go1.16/s390x/Dockerfile.tmpl
+++ b/go1.16/s390x/Dockerfile.tmpl
@@ -57,6 +57,10 @@ RUN cd / \
   && readelf -h helloWorld | grep -c "big endian" \
   && rm helloWorld.c helloWorld
 
+RUN cd /libpcap/libpcap-1.8.1 \
+	&& ./configure --enable-usb=no --enable-bluetooth=no --enable-dbus=no --host=s390x-ibm-linux-gnu --with-pcap=linux \
+	&& make
+
 # Build-time metadata as defined at http://label-schema.org.
 ARG BUILD_DATE
 ARG IMAGE


### PR DESCRIPTION
This PR adds a precompiled version of the libpcap library for each architecture, it requires changes in Beats to use the new precompile libraries. Some architectures that share Docker images have to use a different folder for the library to avoid conflicts. 

* arm64 - /libpcap/libpcap-1.8.1
* armel - /libpcap/libpcap-1.8.1
* armhf - /libpcap/libpcap-1.8.1
* base-arm - /libpcap/libpcap-1.8.1
* i386 - /libpcap/libpcap-1.8.1-i386
* win64 - /libpcap/win/WpdPack
* amd64 - /libpcap/libpcap-1.8.1-amd64
* mips64 - /libpcap/libpcap-1.8.1-mips64
* mips64el - /libpcap/libpcap-1.8.1-mips64el
* mips - /libpcap/libpcap-1.8.1-mips
* mispel - /libpcap/libpcap-1.8.1-mipsel
* ppc64 - /libpcap/libpcap-1.8.1-ppc64
* ppc64el - /libpcap/libpcap-1.8.1-mmpc64el
* s390x -- /libpcap/libpcap-1.8.1

```
git clone git@github.com:elastic/golang-crossbuild.git
cd golang-crossbuild/go1.16
make build
```

related to https://github.com/elastic/golang-crossbuild/issues/63