### PR TITLE
fix: force to install Python 3

### DIFF
--- a/go1.16/base/Dockerfile.tmpl
+++ b/go1.16/base/Dockerfile.tmpl
@@ -18,6 +18,7 @@ RUN apt-get -o Acquire::Check-Valid-Until=false update -y --no-install-recommend
             file \
             flex \
             bison \
+            python3 \
         && rm -rf /var/lib/apt/lists/*
 
 ARG GOLANG_VERSION=1.16.4


### PR DESCRIPTION
Python 3 is not a transitive dependency of any installed package so we have to explicitly install it.

closes https://github.com/elastic/golang-crossbuild/issues/92