### PR TITLE
feat: add suport for darwin/arm64

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ pipeline {
     GO_VERSION = '1.16.4'
   }
   options {
-    timeout(time: 3, unit: 'HOURS')
+    timeout(time: 6, unit: 'HOURS')
     buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '20', daysToKeepStr: '30'))
     timestamps()
     ansiColor('xterm')
@@ -53,16 +53,6 @@ pipeline {
           }
         }
         excludes {
-          exclude {
-            axis {
-              name 'PLATFORM'
-              values 'arm'
-            }
-            axis {
-              name 'GO_FOLDER'
-              values 'go1.14'
-            }
-          }
           exclude {
             axis {
               name 'PLATFORM'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -143,7 +143,9 @@ def buildImages(){
   withGoEnv(){
     dir("${env.BASE_DIR}"){
       def platform = (PLATFORM?.trim().equals('arm')) ? '-arm' : ''
-      sh "make -C ${GO_FOLDER} -f ${MAKEFILE} build${platform}"
+      retryWithSleep(retries: 3, seconds: 15, backoff: true) {
+        sh "make -C ${GO_FOLDER} -f ${MAKEFILE} build${platform}"
+      }
       sh(label: 'list Docker images', script: 'docker images --format "table {{.Repository}}:{{.Tag}}\t{{.Size}}" --filter=reference="docker.elastic.co/beats-dev/golang-crossbuild"')
     }
   }
@@ -154,6 +156,8 @@ def publishImages(){
   dockerLogin(secret: "${env.DOCKER_REGISTRY_SECRET}", registry: "${env.REGISTRY}")
   dir("${env.BASE_DIR}"){
     def platform = (PLATFORM?.trim().equals('arm')) ? '-arm' : ''
-    sh(label: "push docker image to ${env.REPOSITORY}", script: "make -C ${GO_FOLDER} -f ${MAKEFILE} push${platform}")
+    retryWithSleep(retries: 3, seconds: 15, backoff: true) {
+      sh(label: "push docker image to ${env.REPOSITORY}", script: "make -C ${GO_FOLDER} -f ${MAKEFILE} push${platform}")
+    }
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -144,6 +144,7 @@ def buildImages(){
     dir("${env.BASE_DIR}"){
       def platform = (PLATFORM?.trim().equals('arm')) ? '-arm' : ''
       sh "make -C ${GO_FOLDER} -f ${MAKEFILE} build${platform}"
+      sh(label: 'list Docker images', script: 'docker images --format "table {{.Repository}}:{{.Tag}}\t{{.Size}}" --filter=reference="docker.elastic.co/beats-dev/golang-crossbuild"')
     }
   }
 }

--- a/go1.15/main/rootfs/compilers.yaml
+++ b/go1.15/main/rootfs/compilers.yaml
@@ -8,14 +8,6 @@ windows:
     CC:  x86_64-w64-mingw32-gcc
     CXX: x86_64-w64-mingw32-g++
 
-darwin:
-  386:
-    CC:  o32-clang
-    CXX: o32-clang++
-  amd64:
-    CC:  o64-clang
-    CXX: o64-clang++
-
 linux:
   386:
     CC:  gcc

--- a/go1.16/Makefile.debian10
+++ b/go1.16/Makefile.debian10
@@ -1,4 +1,4 @@
-IMAGES         := base arm armhf armel mips mips32 ppc s390x darwin main
+IMAGES         := base main darwin arm armhf armel mips mips32 ppc s390x darwin-arm64
 DEBIAN_VERSION := 10
 TAG_EXTENSION  := -debian10
 

--- a/go1.16/base/Dockerfile.tmpl
+++ b/go1.16/base/Dockerfile.tmpl
@@ -18,8 +18,16 @@ RUN apt-get -o Acquire::Check-Valid-Until=false update -y --no-install-recommend
             file \
             flex \
             bison \
+{{if eq .DEBIAN_VERSION "10"}}
+            python3-venv \
+            python3-pip \
             python3 \
+{{ end }}
         && rm -rf /var/lib/apt/lists/*
+
+{{if eq .DEBIAN_VERSION "10"}}
+RUN ln -s /usr/bin/pip3 /usr/bin/pip
+{{ end }}
 
 ARG GOLANG_VERSION=1.16.4
 ARG GOLANG_DOWNLOAD_URL=https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz

--- a/go1.16/darwin-arm64/Dockerfile.tmpl
+++ b/go1.16/darwin-arm64/Dockerfile.tmpl
@@ -1,0 +1,66 @@
+ARG REPOSITORY
+ARG VERSION
+ARG TAG_EXTENSION=''
+FROM ${REPOSITORY}/golang-crossbuild:${VERSION}-base${TAG_EXTENSION}
+
+RUN \
+    apt-get -o Acquire::Check-Valid-Until=false update \
+    && apt-get install -qq -y --no-install-recommends --allow-unauthenticated \
+        cmake \
+        patch \
+        libssl-dev \
+        libxml2-dev \
+        lzma-dev \
+        uuid-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+{{if eq .DEBIAN_VERSION "10"}}
+ARG OSXCROSS_SDK_URL=https://storage.googleapis.com/obs-ci-cache/beats/MacOSX11.3.sdk.tar.xz
+ARG OSXCROSS_PATH=/usr/osxcross
+ARG OSXCROSS_REV=035cc170338b7b252e3f13b0e3ccbf4411bffc41
+ARG SDK_VERSION=11.3
+ARG DARWIN_VERSION=20
+ARG OSX_VERSION_MIN=11.3
+{{ else }}
+RUN echo "This Docker image will work only with Debian 10" && exit 1
+{{ end }}
+
+RUN \
+    mkdir -p /tmp/osxcross && cd /tmp/osxcross \
+    && curl -sSL "https://codeload.github.com/tpoechtrager/osxcross/tar.gz/${OSXCROSS_REV}" \
+        | tar -C /tmp/osxcross --strip=1 -xzf - \
+    && curl -sSLo "tarballs/MacOSX${SDK_VERSION}.sdk.tar.xz" "${OSXCROSS_SDK_URL}" \
+    && UNATTENDED=yes ENABLE_CLANG_INSTALL=yes ./build_clang.sh >/dev/null \
+    && UNATTENDED=yes ./build.sh >/dev/null \
+    && mv target "${OSXCROSS_PATH}" \
+    && rm -rf /tmp/osxcross "/usr/osxcross/SDK/MacOSX${SDK_VERSION}.sdk/usr/share/man"
+
+ENV PATH $OSXCROSS_PATH/bin:$PATH
+# Add osxcross libraries to the library PATH
+ENV LD_LIBRARY_PATH /usr/osxcross/lib:$LD_LIBRARY_PATH
+
+COPY rootfs /
+
+# Basic test
+RUN cd / \
+  && o64-clang helloWorld.c -o helloWorld \
+  && file helloWorld \
+  && file helloWorld | grep -c 'Mach-O 64-bit x86_64'
+
+RUN cd / \
+  && oa64-clang helloWorld.c -o helloWorld \
+  && file helloWorld \
+  && file helloWorld | grep -c 'Mach-O 64-bit arm64' \
+  && rm helloWorld helloWorld.c
+
+
+# Build-time metadata as defined at http://label-schema.org.
+ARG BUILD_DATE
+ARG IMAGE
+ARG VCS_REF
+ARG VCS_URL
+LABEL org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.name=$IMAGE \
+      org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.vcs-url=$VCS_URL \
+      org.label-schema.schema-version="1.0"

--- a/go1.16/darwin-arm64/Makefile
+++ b/go1.16/darwin-arm64/Makefile
@@ -1,0 +1,1 @@
+include ../Makefile.common

--- a/go1.16/darwin-arm64/rootfs/compilers.yaml
+++ b/go1.16/darwin-arm64/rootfs/compilers.yaml
@@ -1,0 +1,9 @@
+---
+
+darwin:
+  amd64:
+    CC:  o64-clang
+    CXX: o64-clang++
+  arm64:
+    CC:  oa64-clang
+    CXX: oa64-clang++

--- a/go1.16/darwin-arm64/rootfs/helloWorld.c
+++ b/go1.16/darwin-arm64/rootfs/helloWorld.c
@@ -1,0 +1,5 @@
+#include <stdio.h>
+int main() {
+   printf("Hello, World!");
+   return 0;
+}

--- a/go1.16/darwin/Dockerfile.tmpl
+++ b/go1.16/darwin/Dockerfile.tmpl
@@ -10,7 +10,9 @@ RUN \
         llvm \
         cmake \
         patch \
+{{if ne .DEBIAN_VERSION "10"}}
         python \
+{{ end }}
         libssl-dev \
         libxml2-dev \
         lzma-dev \
@@ -24,7 +26,7 @@ ARG OSXCROSS_PATH=/usr/osxcross
 ARG OSXCROSS_REV=8a716a43a72dab1db9630d7824ee0af3730cb8f9
 ARG SDK_VERSION=10.14
 ARG DARWIN_VERSION=17
-ARG OSX_VERSION_MIN=10.14
+ARG OSX_VERSION_MIN=10.10
 {{ else }}
 ARG OSXCROSS_SDK_URL=https://storage.googleapis.com/obs-ci-cache/beats/MacOSX10.11.sdk.tar.xz
 ARG OSXCROSS_PATH=/usr/osxcross


### PR DESCRIPTION
This PR adds support for compile binaries for darwin/arm64, it compiles clang and LLVM before compiling [osxcross](https://github.com/tpoechtrager/osxcross) this takes a few hours but at the moment the version of clang and LLVM provided by Debian does not support this architecture.

it does not support darwin/arm64e it requires to use [apple's LLVM fork](https://github.com/apple/llvm-project) 
https://stackoverflow.com/questions/52624308/xcode-arm64-vs-arm64e

other changes in this PR:
* chore: set OSX_VERSION_MIN to 10.10 on SDK 10.14
* chore: do not install python on Debian 10 is installed
* chore: remove compilers no available in main 
* feat: list Docker images
* chore: pipeline increase timeout

related to https://github.com/elastic/golang-crossbuild/issues/94