### PR TITLE
feat: support for darwin/arm64e

### DIFF
--- a/go/darwin-arm64/Dockerfile.tmpl
+++ b/go/darwin-arm64/Dockerfile.tmpl
@@ -40,20 +40,24 @@ COPY rootfs /
 
 # Basic test
 RUN cd / \
-  && o64-clang helloWorld.c -o helloWorld \
-  && file helloWorld \
-  && file helloWorld | grep -c 'Mach-O 64-bit x86_64'
+  && o64-clang helloWorld.c -o helloWorld.x86_64 \
+  && file helloWorld.x86_64 \
+  && file helloWorld.x86_64 | grep -c 'Mach-O 64-bit x86_64'
 
 RUN cd / \
-  && oa64-clang helloWorld.c -o helloWorld \
-  && file helloWorld \
-  && file helloWorld | grep -c 'Mach-O 64-bit arm64'
+  && oa64-clang helloWorld.c -o helloWorld.arm64 \
+  && file helloWorld.arm64 \
+  && file helloWorld.arm64 | grep -c 'Mach-O 64-bit arm64'
 
 RUN cd / \
-  && oa64e-clang helloWorld.c -o helloWorld \
-  && file helloWorld \
-  && file helloWorld | grep -c 'Mach-O 64-bit arm64' \
-  && rm helloWorld helloWorld.c
+  && oa64e-clang helloWorld.c -o helloWorld.arm64e \
+  && file helloWorld.arm64e \
+  && file helloWorld.arm64e | grep -c 'Mach-O 64-bit arm64'
+
+RUN cd / \
+  && lipo -create -output helloWorld.universal helloWorld.x86_64 helloWorld.arm64e \
+  && file helloWorld.universal | grep 'Mach-O universal binary' \
+  && rm helloWorld.*
 
 
 # Build-time metadata as defined at http://label-schema.org.

--- a/go/darwin-arm64/Dockerfile.tmpl
+++ b/go/darwin-arm64/Dockerfile.tmpl
@@ -1,7 +1,7 @@
 ARG REPOSITORY
 ARG VERSION
 ARG TAG_EXTENSION=''
-FROM ${REPOSITORY}/golang-crossbuild:${VERSION}-llvm-apple${TAG_EXTENSION} AS BUILD_LLVM_APPLE
+FROM docker.elastic.co/beats-dev/golang-crossbuild:${VERSION}-llvm-apple${TAG_EXTENSION} AS BUILD_LLVM_APPLE
 
 ARG REPOSITORY
 ARG VERSION
@@ -18,7 +18,7 @@ RUN \
         lzma-dev \
         uuid-dev \
     && rm -rf /var/lib/apt/lists/*
-    
+
 {{if or (eq .DEBIAN_VERSION "10") (eq .DEBIAN_VERSION "11")}}
 COPY --from=BUILD_LLVM_APPLE /llvm-apple-Linux.tar.gz /tmp/llvm-apple-Linux.tar.gz
 RUN tar -xzf /tmp/llvm-apple-Linux.tar.gz --strip 1 -C /usr/local \

--- a/go/darwin-arm64/Dockerfile.tmpl
+++ b/go/darwin-arm64/Dockerfile.tmpl
@@ -1,6 +1,11 @@
 ARG REPOSITORY
 ARG VERSION
 ARG TAG_EXTENSION=''
+FROM ${REPOSITORY}/golang-crossbuild:${VERSION}-llvm-apple${TAG_EXTENSION} AS BUILD_LLVM_APPLE
+
+ARG REPOSITORY
+ARG VERSION
+ARG TAG_EXTENSION=''
 FROM ${REPOSITORY}/golang-crossbuild:${VERSION}-base${TAG_EXTENSION}
 
 RUN \
@@ -14,30 +19,18 @@ RUN \
         uuid-dev \
     && rm -rf /var/lib/apt/lists/*
 
-{{if eq .DEBIAN_VERSION "10"}}
-ARG OSXCROSS_SDK_URL=https://storage.googleapis.com/obs-ci-cache/beats/MacOSX11.3.sdk.tar.xz
-ARG OSXCROSS_PATH=/usr/osxcross
-ARG OSXCROSS_REV=035cc170338b7b252e3f13b0e3ccbf4411bffc41
-ARG SDK_VERSION=11.3
-ARG DARWIN_VERSION=20
-ARG OSX_VERSION_MIN=11.3
-{{ else }}
-RUN echo "This Docker image will work only with Debian 10" && exit 1
-{{ end }}
+COPY --from=BUILD_LLVM_APPLE /llvm-apple-Linux.tar.gz /tmp/llvm-apple-Linux.tar.gz
+RUN tar -xzf /tmp/llvm-apple-Linux.tar.gz --strip 1 -C /usr/local \
+  && rm /tmp/llvm-apple-Linux.tar.gz
 
-RUN \
-    mkdir -p /tmp/osxcross && cd /tmp/osxcross \
-    && curl -sSL "https://codeload.github.com/tpoechtrager/osxcross/tar.gz/${OSXCROSS_REV}" \
-        | tar -C /tmp/osxcross --strip=1 -xzf - \
-    && curl -sSLo "tarballs/MacOSX${SDK_VERSION}.sdk.tar.xz" "${OSXCROSS_SDK_URL}" \
-    && UNATTENDED=yes ENABLE_CLANG_INSTALL=yes ./build_clang.sh >/dev/null \
-    && UNATTENDED=yes ./build.sh >/dev/null \
-    && mv target "${OSXCROSS_PATH}" \
-    && rm -rf /tmp/osxcross "/usr/osxcross/SDK/MacOSX${SDK_VERSION}.sdk/usr/share/man"
+ARG OSXCROSS_PATH=/usr/local/osxcross
+COPY --from=BUILD_LLVM_APPLE /osxcross.tar.gz /tmp/osxcross.tar.gz
+RUN tar -xzf /tmp/osxcross.tar.gz -C / \
+  && rm /tmp/osxcross.tar.gz
 
-ENV PATH $OSXCROSS_PATH/bin:$PATH
+ENV PATH $PATH:$OSXCROSS_PATH/bin
 # Add osxcross libraries to the library PATH
-ENV LD_LIBRARY_PATH /usr/osxcross/lib:$LD_LIBRARY_PATH
+ENV LD_LIBRARY_PATH ${OSXCROSS_PATH}/lib:$LD_LIBRARY_PATH
 
 COPY rootfs /
 
@@ -49,6 +42,11 @@ RUN cd / \
 
 RUN cd / \
   && oa64-clang helloWorld.c -o helloWorld \
+  && file helloWorld \
+  && file helloWorld | grep -c 'Mach-O 64-bit arm64'
+
+RUN cd / \
+  && oa64e-clang helloWorld.c -o helloWorld \
   && file helloWorld \
   && file helloWorld | grep -c 'Mach-O 64-bit arm64' \
   && rm helloWorld helloWorld.c

--- a/go/darwin-arm64/Dockerfile.tmpl
+++ b/go/darwin-arm64/Dockerfile.tmpl
@@ -1,7 +1,7 @@
 ARG REPOSITORY
 ARG VERSION
 ARG TAG_EXTENSION=''
-FROM docker.elastic.co/beats-dev/golang-crossbuild:${VERSION}-llvm-apple${TAG_EXTENSION} AS BUILD_LLVM_APPLE
+FROM docker.elastic.co/beats-dev/golang-crossbuild:llvm-apple${TAG_EXTENSION} AS BUILD_LLVM_APPLE
 
 ARG REPOSITORY
 ARG VERSION

--- a/go/darwin/Dockerfile.tmpl
+++ b/go/darwin/Dockerfile.tmpl
@@ -1,3 +1,10 @@
+{{- if or (eq .DEBIAN_VERSION "10") (eq .DEBIAN_VERSION "11")}}
+ARG REPOSITORY
+ARG VERSION
+ARG TAG_EXTENSION=''
+FROM docker.elastic.co/beats-dev/golang-crossbuild:llvm-apple${TAG_EXTENSION} AS BUILD_LLVM_APPLE
+{{- end }}
+
 ARG REPOSITORY
 ARG VERSION
 ARG TAG_EXTENSION=''
@@ -21,12 +28,10 @@ RUN \
     && rm -rf /var/lib/apt/lists/*
 
 {{- if or (eq .DEBIAN_VERSION "10") (eq .DEBIAN_VERSION "11")}}
-ARG OSXCROSS_SDK_URL=https://storage.googleapis.com/obs-ci-cache/beats/MacOSX10.14.sdk.tar.xz
-ARG OSXCROSS_PATH=/usr/osxcross
-ARG OSXCROSS_REV=8a716a43a72dab1db9630d7824ee0af3730cb8f9
-ARG SDK_VERSION=10.14
-ARG DARWIN_VERSION=17
-ARG OSX_VERSION_MIN=10.10
+ARG OSXCROSS_PATH=/usr/local/osxcross
+COPY --from=BUILD_LLVM_APPLE /osxcross.tar.gz /tmp/osxcross.tar.gz
+RUN tar -xzf /tmp/osxcross.tar.gz -C / \
+  && rm /tmp/osxcross.tar.gz
 {{- else }}
 ARG OSXCROSS_SDK_URL=https://storage.googleapis.com/obs-ci-cache/beats/MacOSX10.11.sdk.tar.xz
 ARG OSXCROSS_PATH=/usr/osxcross
@@ -34,8 +39,6 @@ ARG OSXCROSS_REV=3034f7149716d815bc473d0a7b35d17e4cf175aa
 ARG SDK_VERSION=10.11
 ARG DARWIN_VERSION=15
 ARG OSX_VERSION_MIN=10.10
-{{- end }}
-
 RUN \
     mkdir -p /tmp/osxcross && cd /tmp/osxcross \
     && curl -sSL "https://codeload.github.com/tpoechtrager/osxcross/tar.gz/${OSXCROSS_REV}" \
@@ -44,10 +47,11 @@ RUN \
     && UNATTENDED=yes ./build.sh >/dev/null \
     && mv target "${OSXCROSS_PATH}" \
     && rm -rf /tmp/osxcross "/usr/osxcross/SDK/MacOSX${SDK_VERSION}.sdk/usr/share/man"
+{{- end }}
 
-ENV PATH $OSXCROSS_PATH/bin:$PATH
+ENV PATH $PATH:$OSXCROSS_PATH/bin
 # Add osxcross libraries to the library PATH
-ENV LD_LIBRARY_PATH /usr/osxcross/lib:$LD_LIBRARY_PATH
+ENV LD_LIBRARY_PATH ${OSXCROSS_PATH}/lib:$LD_LIBRARY_PATH
 
 COPY rootfs /
 


### PR DESCRIPTION
This PR adds support for darwin/arm64e architecture. To do that it compiles [Apple's LLVM](https://github.com/apple/llvm-project) then compiles [osxcross](https://github.com/tpoechtrager/osxcross). It takes about 3h to build the image.

depends on https://github.com/elastic/golang-crossbuild/pull/182