### PR TITLE
fix: force gcc to build libpcap

### DIFF
--- a/go1.15/arm/Dockerfile.tmpl
+++ b/go1.15/arm/Dockerfile.tmpl
@@ -59,7 +59,7 @@ RUN cd / \
   && rm helloWorld.c helloWorld
 
 RUN cd /libpcap/libpcap-1.8.1 \
-	&& ./configure --enable-usb=no --enable-bluetooth=no --enable-dbus=no --host=aarch64-unknown-linux-gnu --with-pcap=linux \
+	&& CC=aarch64-linux-gnu-gcc ./configure --enable-usb=no --enable-bluetooth=no --enable-dbus=no --host=aarch64-unknown-linux-gnu --with-pcap=linux \
 	&& make
 
 # Build-time metadata as defined at http://label-schema.org.

--- a/go1.15/armel/Dockerfile.tmpl
+++ b/go1.15/armel/Dockerfile.tmpl
@@ -59,7 +59,7 @@ RUN cd / \
   && rm helloWorld.c helloWorld
 
 RUN cd /libpcap/libpcap-1.8.1 \
-	&& ./configure --enable-usb=no --enable-bluetooth=no --enable-dbus=no --host=arm-linux-gnueabi --with-pcap=linux \
+	&& CC=arm-linux-gnueabi-gcc ./configure --enable-usb=no --enable-bluetooth=no --enable-dbus=no --host=arm-linux-gnueabi --with-pcap=linux \
 	&& make
 
 # Build-time metadata as defined at http://label-schema.org.

--- a/go1.15/armhf/Dockerfile.tmpl
+++ b/go1.15/armhf/Dockerfile.tmpl
@@ -59,7 +59,7 @@ RUN cd / \
   && rm helloWorld.c helloWorld
 
 RUN cd /libpcap/libpcap-1.8.1 \
-	&& ./configure --enable-usb=no --enable-bluetooth=no --enable-dbus=no --host=arm-linux-gnueabihf --with-pcap=linux \
+	&& CC=arm-linux-gnueabihf-gcc ./configure --enable-usb=no --enable-bluetooth=no --enable-dbus=no --host=arm-linux-gnueabihf --with-pcap=linux \
 	&& make
 
 # Build-time metadata as defined at http://label-schema.org.

--- a/go1.16/arm/Dockerfile.tmpl
+++ b/go1.16/arm/Dockerfile.tmpl
@@ -59,7 +59,7 @@ RUN cd / \
   && rm helloWorld.c helloWorld
 
 RUN cd /libpcap/libpcap-1.8.1 \
-	&& ./configure --enable-usb=no --enable-bluetooth=no --enable-dbus=no --host=aarch64-unknown-linux-gnu --with-pcap=linux \
+	&& CC=aarch64-linux-gnu-gcc ./configure --enable-usb=no --enable-bluetooth=no --enable-dbus=no --host=aarch64-unknown-linux-gnu --with-pcap=linux \
 	&& make
 
 # Build-time metadata as defined at http://label-schema.org.

--- a/go1.16/armel/Dockerfile.tmpl
+++ b/go1.16/armel/Dockerfile.tmpl
@@ -59,7 +59,7 @@ RUN cd / \
   && rm helloWorld.c helloWorld
 
 RUN cd /libpcap/libpcap-1.8.1 \
-	&& ./configure --enable-usb=no --enable-bluetooth=no --enable-dbus=no --host=arm-linux-gnueabi --with-pcap=linux \
+	&& CC=arm-linux-gnueabi-gcc ./configure --enable-usb=no --enable-bluetooth=no --enable-dbus=no --host=arm-linux-gnueabi --with-pcap=linux \
 	&& make
 
 # Build-time metadata as defined at http://label-schema.org.

--- a/go1.16/armhf/Dockerfile.tmpl
+++ b/go1.16/armhf/Dockerfile.tmpl
@@ -59,7 +59,7 @@ RUN cd / \
   && rm helloWorld.c helloWorld
 
 RUN cd /libpcap/libpcap-1.8.1 \
-	&& ./configure --enable-usb=no --enable-bluetooth=no --enable-dbus=no --host=arm-linux-gnueabihf --with-pcap=linux \
+	&& CC=arm-linux-gnueabihf-gcc ./configure --enable-usb=no --enable-bluetooth=no --enable-dbus=no --host=arm-linux-gnueabihf --with-pcap=linux \
 	&& make
 
 # Build-time metadata as defined at http://label-schema.org.


### PR DESCRIPTION
In some architectures the libpcap configure does not find the correct gcc to use so it uses gcc generating x86_64 binaries, those binaries are not valid for other architectures. This PR force the configure to use the right gcc for each architecture.

related to https://github.com/elastic/golang-crossbuild/issues/63 https://github.com/elastic/beats/pull/25769