### PR TITLE
Bump golang version with the latest supported one

### DIFF
--- a/.ci/bump-go-release-version.sh
+++ b/.ci/bump-go-release-version.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+#
+# Given the Golang release version this script will bump the version.
+#
+# This script is executed by the automation we are putting in place
+# and it requires the git add/commit commands.
+#
+# NOTE: sha256 is retrieved from https://pkg.go.dev/golang.org/x/website/internal/dl?utm_source=godoc
+#
+# Parameters:
+#	$1 -> the Golang release version to be bumped. Mandatory.
+#
+set -euo pipefail
+MSG="parameter missing."
+GO_RELEASE_VERSION=${1:?$MSG}
+OS=$(uname -s| tr '[:upper:]' '[:lower:]')
+if [ "${OS}" == "darwin" ] ; then
+	SED="sed -i .bck"
+else
+	SED="sed -i"
+fi
+
+MAJOR_MINOR_VERSION=$(echo "$GO_RELEASE_VERSION" | sed -E -e "s#([0-9]+\.[0-9]+).*#\1#g")
+
+GO_FOLDER="go${MAJOR_MINOR_VERSION}"
+if [ -d "${GO_FOLDER}" ] ; then
+    echo "Update go version ${GO_RELEASE_VERSION}"
+    ${SED} -E -e "s#(VERSION[[:space:]]+):= .*#\1:= ${GO_RELEASE_VERSION}#g" "${GO_FOLDER}/Makefile.common"
+    git add "${GO_FOLDER}/Makefile.common"
+    ${SED} -E -e "s#(GO_VERSION[[:space:]]+)= .*#\1= '${GO_RELEASE_VERSION}'#g" Jenkinsfile
+    git add Jenkinsfile
+
+    find "${GO_FOLDER}" -type f -name Dockerfile.tmpl -print0 |
+        while IFS= read -r -d '' line; do
+            ${SED} -E -e "s#(ARG GOLANG_VERSION)=[0-9]+\.[0-9]+\.[0-9]+#\1=${GO_RELEASE_VERSION}#g" "$line"
+            GOLANG_DOWNLOAD_SHA256=$(curl -s https://golang.org/dl/\?mode\=json | jq -r ".[] | select( .version | contains(\"go${GO_RELEASE_VERSION}\")) | .files[] | select (.filename | contains(\"go${GO_RELEASE_VERSION}.linux-arm64.tar.gz\")) | .sha256")
+            ${SED} -E -e "s#(ARG GOLANG_DOWNLOAD_SHA256)=.+#\1=${GOLANG_DOWNLOAD_SHA256}#g" "$line"
+            git add "${line}"
+        done
+
+    git diff --staged --quiet || git commit -m "[Automation] Update go release version to ${GO_RELEASE_VERSION}"
+    git --no-pager log -1
+
+    echo "You can now push and create a Pull Request"
+else
+    echo "A new minor version has been released. Bump cannot happen"
+    echo "Add Golang go${MAJOR_MINOR_VERSION} crossbuild images."
+    echo "See https://github.com/elastic/golang-crossbuild/pull/85"
+    echo "You might need to deprecate one of the existing Golang versions since"
+    echo "we only support the last two releases."
+    exit 1
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 _obj
 Dockerfile
 .status.*
+*.bck

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,12 @@
+pull_request_rules:
+  - name: delete upstream branch after merging changes on Jenkinsfile or it's closed
+    conditions:
+      - or:
+        - merged
+        - closed
+      - and:
+        - label=automation
+        - head~=^update-go-version
+        - files~=^Jenkinsfile$
+    actions:
+      delete_head_branch:


### PR DESCRIPTION
### What

I used https://github.com/elastic/golang-crossbuild/pull/106 and https://github.com/elastic/golang-crossbuild/pull/107 as the references for the implementation.

It only supports the latest existing minor version, `1.16` at the moment.

For a bump of minor versions, the automation does not work yet, since it requires some other actions:

- Create the `go1.17` folder structure with its files
- Update the README.md
- Remove `go1.15` folder

You can use this script locally:

```bash
.ci/bump-go-release-version.sh <new-go-version>
```

NOTE: it will add and commit the changes in the existing branch. The push and PR creation is not done within this script.

### Why

No more manual actions.

## Further details

This automation will not merge the PR automatically. We do want the teams to do so:
- Review the changes and validate the CI status
- Merge when needed.
- Create PR in the beats project with the bump.

This particular automation will run on weekly basis. The pipeline is [bump-go-release-version-pipeline](https://apm-ci.elastic.co/job/apm-shared/job/bump-go-release-version-pipeline/)

### Test

If we want to support `go1.17` then:

Given:

```bash
$ .ci/bump-go-release-version.sh 1.17.1
```

produces:

```
.ci/bump-go-release-version.sh 1.17.1
A new minor version has been released. Bump cannot happen
Add Golang go1.17 crossbuild images.
See https://github.com/elastic/golang-crossbuild/pull/85
You might need to deprecate one of the existing Golang versions since
we only support the last two releases.
➜  golang-crossbuild git:(feature/upgrade-golang-crossbuild) ✗ echo $?   
1
```

Hypothetically `1.16.6` was released then

Given:

```bash
$ .ci/bump-go-release-version.sh 1.16.6                            
Update go version 1.16.6
[feature/upgrade-golang-crossbuild f5d5094] [Automation] Update go release version to 1.16.6
 4 files changed, 6 insertions(+), 6 deletions(-)
commit f5d5094aede5912ad8a34092ff51ca550687778d (HEAD -> feature/upgrade-golang-crossbuild)
Author: Victor Martinez <VictorMartinezRubio@gmail.com>
Date:   Fri Jun 18 14:03:09 2021 +0100

    [Automation] Update go release version to 1.16.6
You can now push and create a Pull Request

```

SHA256 requires the release to exist, that's the reason is empty!

produces:

```diff
diff --git a/Jenkinsfile b/Jenkinsfile
index 040dc56..158d48e 100644
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
     DOCKER_REGISTRY_SECRET = 'secret/observability-team/ci/docker-registry/prod'
     REGISTRY = 'docker.elastic.co'
     STAGING_IMAGE = "${env.REGISTRY}/observability-ci"
-    GO_VERSION = '1.16.4'
+    GO_VERSION = '1.16.6'
   }
   options {
     timeout(time: 3, unit: 'HOURS')
diff --git a/go1.16/Makefile.common b/go1.16/Makefile.common
index 9dbab81..21d289b 100644
--- a/go1.16/Makefile.common
+++ b/go1.16/Makefile.common
@@ -2,7 +2,7 @@ SELF_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 include $(SELF_DIR)/../Makefile.common
 
 NAME           := golang-crossbuild
-VERSION        := 1.16.5
+VERSION        := 1.16.6
 DEBIAN_VERSION ?= 9
 SUFFIX         := -$(shell basename $(CURDIR))
 TAG_EXTENSION  ?=
diff --git a/go1.16/base-arm/Dockerfile.tmpl b/go1.16/base-arm/Dockerfile.tmpl
index d43a2be..6328521 100644
--- a/go1.16/base-arm/Dockerfile.tmpl
+++ b/go1.16/base-arm/Dockerfile.tmpl
@@ -37,9 +37,9 @@ RUN \
             libsqlite3-0 \
         && rm -rf /var/lib/apt/lists/*
 
-ARG GOLANG_VERSION=1.16.5
+ARG GOLANG_VERSION=1.16.6
 ARG GOLANG_DOWNLOAD_URL=https://golang.org/dl/go$GOLANG_VERSION.linux-arm64.tar.gz
-ARG GOLANG_DOWNLOAD_SHA256=d5446b46ef6f36fdffa852f73dfbbe78c1ddf010b99fa4964944b9ae8b4d6799
+ARG GOLANG_DOWNLOAD_SHA256=
 
 RUN curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz \
 	&& echo "$GOLANG_DOWNLOAD_SHA256  golang.tar.gz" | sha256sum -c - \
diff --git a/go1.16/base/Dockerfile.tmpl b/go1.16/base/Dockerfile.tmpl
index 7bd9085..1f53e6b 100644
--- a/go1.16/base/Dockerfile.tmpl
+++ b/go1.16/base/Dockerfile.tmpl
@@ -29,9 +29,9 @@ RUN apt-get -o Acquire::Check-Valid-Until=false update -y --no-install-recommend
 RUN ln -s /usr/bin/pip3 /usr/bin/pip
 {{ end }}
 
-ARG GOLANG_VERSION=1.16.5
+ARG GOLANG_VERSION=1.16.6
 ARG GOLANG_DOWNLOAD_URL=https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
-ARG GOLANG_DOWNLOAD_SHA256=b12c23023b68de22f74c0524f10b753e7b08b1504cb7e417eccebdd3fae49061
+ARG GOLANG_DOWNLOAD_SHA256=
 
 RUN curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz \
 	&& echo "$GOLANG_DOWNLOAD_SHA256  golang.tar.gz" | sha256sum -c - \

```