### PR TITLE
Update FPM to 1.13.1

### DIFF
--- a/fpm/Dockerfile.tmpl
+++ b/fpm/Dockerfile.tmpl
@@ -1,4 +1,4 @@
-FROM debian:stretch
+FROM debian:buster
 LABEL maintainer="Elastic Beats Team"
 
 RUN \

--- a/fpm/Makefile
+++ b/fpm/Makefile
@@ -1,7 +1,7 @@
 include ../Makefile.common
 
 NAME    := fpm
-VERSION := 1.11.0
+VERSION := 1.13.1
 
 build:
 	@echo ">> Building $(REPOSITORY)/$(NAME):$(VERSION)$(SUFFIX)"


### PR DESCRIPTION
This updates the FPM image to include 1.13.1. And it updates the
base image to debian:buster which has a newer version of RPM that
supports sha256 digests.

    # rpm --version
    RPM version 4.14.2.1
    # fpm --version
    1.13.1