### PR TITLE
CI: allow caching to rebuild if needed

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -97,10 +97,12 @@ pipeline {
         stages {
           stage('Build') {
             steps {
-              withGithubNotify(context: "Build ${GO_FOLDER} ${MAKEFILE} ${PLATFORM}") {
-                deleteDir()
-                unstash 'source'
-                buildImages()
+              stageStatusCache(id: "Build ${GO_FOLDER} ${MAKEFILE} ${PLATFORM}") {
+                withGithubNotify(context: "Build ${GO_FOLDER} ${MAKEFILE} ${PLATFORM}") {
+                  deleteDir()
+                  unstash 'source'
+                  buildImages()
+                }
               }
             }
           }
@@ -109,11 +111,13 @@ pipeline {
               REPOSITORY = "${env.STAGING_IMAGE}"
             }
             steps {
-              withGithubNotify(context: "Staging ${GO_FOLDER} ${MAKEFILE} ${PLATFORM}") {
-                // It will use the already cached docker images that were created in the
-                // Build stage. But it's required to retag them with the staging repo.
-                buildImages()
-                publishImages()
+              stageStatusCache(id: "Staging ${GO_FOLDER} ${MAKEFILE} ${PLATFORM}") {
+                withGithubNotify(context: "Staging ${GO_FOLDER} ${MAKEFILE} ${PLATFORM}") {
+                  // It will use the already cached docker images that were created in the
+                  // Build stage. But it's required to retag them with the staging repo.
+                  buildImages()
+                  publishImages()
+                }
               }
             }
           }


### PR DESCRIPTION
### What

Enable https://github.com/elastic/apm-pipeline-library/tree/master/vars#stagestatuscache to allow rebuilding the CI build for the same commit.

### Why

This particular pipeline does build and push docker images, it takes a bit of time, and could happen that some third-party networking was not accessible, so rather than building from scratch everything let's use `stageStatusCache` to actually rebuild what's needed. 


### Test


![image](https://user-images.githubusercontent.com/2871786/136003506-e10335e0-342a-4e1c-bb48-659838e65750.png)
