### PR TITLE
internal: use google storage bucket for WpdPack_4_1_2.zip

### DIFF
--- a/go1.16/main/Dockerfile.tmpl
+++ b/go1.16/main/Dockerfile.tmpl
@@ -54,7 +54,7 @@ RUN cd /libpcap/libpcap-1.8.1 \
   && ./configure --enable-usb=no --enable-bluetooth=no --enable-dbus=no \
   && make
 
-RUN curl -sSLO https://www.winpcap.org/install/bin/WpdPack_4_1_2.zip \
+RUN curl -sSLO https://storage.googleapis.com/obs-ci-cache/beats/WpdPack_4_1_2.zip \
   && mkdir -p /libpcap/win \
   && echo "ea799cf2f26e4afb1892938070fd2b1ca37ce5cf75fec4349247df12b784edbd  WpdPack_4_1_2.zip" | sha256sum -c - \
   && unzip WpdPack_4_1_2.zip -d /libpcap/win \

--- a/go1.17/main/Dockerfile.tmpl
+++ b/go1.17/main/Dockerfile.tmpl
@@ -54,7 +54,7 @@ RUN cd /libpcap/libpcap-1.8.1 \
   && ./configure --enable-usb=no --enable-bluetooth=no --enable-dbus=no \
   && make
 
-RUN curl -sSLO https://www.winpcap.org/install/bin/WpdPack_4_1_2.zip \
+RUN curl -sSLO https://storage.googleapis.com/obs-ci-cache/beats/WpdPack_4_1_2.zip \
   && mkdir -p /libpcap/win \
   && echo "ea799cf2f26e4afb1892938070fd2b1ca37ce5cf75fec4349247df12b784edbd  WpdPack_4_1_2.zip" | sha256sum -c - \
   && unzip WpdPack_4_1_2.zip -d /libpcap/win \


### PR DESCRIPTION
### What

Use the google storage bucket to download `WpdPack_4_1_2.zip` from.

### Why

Avoid CA certificate issues and reduce the need of a third party system while the google storage bucket is already something we have put in place for some other binaries.

