### PR TITLE
release: automate changelog generation

### DIFF
--- a/.ci/scripts/release-notes.sh
+++ b/.ci/scripts/release-notes.sh
@@ -4,4 +4,4 @@ set +x
 
 GREN_GITHUB_TOKEN=${GREN_GITHUB_TOKEN:?"missing GREN_GITHUB_TOKEN"}
 
-gren release --token="${GREN_GITHUB_TOKEN}" -c .grenrc.js --
+gren release --token="${GREN_GITHUB_TOKEN}" -c .grenrc.js --limit 2

--- a/.ci/scripts/release-notes.sh
+++ b/.ci/scripts/release-notes.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -ueo pipefail
+set +x
+
+GREN_GITHUB_TOKEN=${GREN_GITHUB_TOKEN:?"missing GREN_GITHUB_TOKEN"}
+
+gren release --token="${GREN_GITHUB_TOKEN}" -c .grenrc.js --

--- a/.grenrc.js
+++ b/.grenrc.js
@@ -1,0 +1,42 @@
+module.exports = {
+    "dataSource": "prs",
+    "prefix": "",
+    "onlyMilestones": false,
+    "ignoreCommitsWith": ["chore", "refactor", "style"],
+    "ignoreIssuesWith": ["no-release"],
+    "ignoreTagsWith": ["-rc", "-alpha", "-beta", "test", "current"],
+    "ignoreLabels": ["closed", "automation", "enhancement", "bug", "fix",
+      "internal", "feature", "feat", "docs", "chore", "refactor", "ci",
+      "perf", "test", "tests", "style", "groovy", "linux", "master", "mac", "windows"],
+    "groupBy": {
+        "Enhancements": ["enhancement", "internal", "feature", "feat"],
+        "Bug Fixes": ["bug", "fix"],
+        "Documentation": ["docs", "question"],
+        "No user affected": ["chore", "refactor", "perf", "test", "style"],
+        "CI": ["ci"]
+    },
+    "template": {
+        commit: ({ message, url, author, name }) => `- [${message}](${url}) - ${author ? `@${author}` : name}`,
+        issue: "- {{labels}} {{name}} [{{text}}]({{url}})",
+        label: "[**{{label}}**]",
+        noLabel: "closed",
+        changelogTitle: "# Changelog\n\n",
+        release: "## {{release}} ({{date}})\n{{body}}",
+        releaseSeparator: "\n---\n\n",
+        group: function (placeholders) {
+          var icon = "🙈"
+          if(placeholders.heading == 'Enhancements'){
+            icon = "🚀"
+          } else if(placeholders.heading == 'Bug Fixes'){
+            icon = "🐛"
+          } else if(placeholders.heading == 'Documentation'){
+            icon = "📚"
+          } else if(placeholders.heading == 'No user affected'){
+            icon = "🙈"
+          } else if(placeholders.heading == 'CI'){
+            icon = "⚙️"
+          }
+          return '\n#### ' + icon + ' ' + placeholders.heading + '\n';
+        }
+    }
+}

--- a/.grenrc.js
+++ b/.grenrc.js
@@ -1,42 +1,38 @@
 module.exports = {
-    "dataSource": "prs",
-    "prefix": "",
-    "onlyMilestones": false,
-    "ignoreCommitsWith": ["chore", "refactor", "style"],
-    "ignoreIssuesWith": ["no-release"],
-    "ignoreTagsWith": ["-rc", "-alpha", "-beta", "test", "current"],
-    "ignoreLabels": ["closed", "automation", "enhancement", "bug", "fix",
-      "internal", "feature", "feat", "docs", "chore", "refactor", "ci",
-      "perf", "test", "tests", "style", "groovy", "linux", "master", "mac", "windows"],
-    "groupBy": {
-        "Enhancements": ["enhancement", "internal", "feature", "feat"],
-        "Bug Fixes": ["bug", "fix"],
-        "Documentation": ["docs", "question"],
-        "No user affected": ["chore", "refactor", "perf", "test", "style"],
-        "CI": ["ci"]
-    },
-    "template": {
-        commit: ({ message, url, author, name }) => `- [${message}](${url}) - ${author ? `@${author}` : name}`,
-        issue: "- {{labels}} {{name}} [{{text}}]({{url}})",
-        label: "[**{{label}}**]",
-        noLabel: "closed",
-        changelogTitle: "# Changelog\n\n",
-        release: "## {{release}} ({{date}})\n{{body}}",
-        releaseSeparator: "\n---\n\n",
-        group: function (placeholders) {
-          var icon = "🙈"
-          if(placeholders.heading == 'Enhancements'){
-            icon = "🚀"
-          } else if(placeholders.heading == 'Bug Fixes'){
-            icon = "🐛"
-          } else if(placeholders.heading == 'Documentation'){
-            icon = "📚"
-          } else if(placeholders.heading == 'No user affected'){
-            icon = "🙈"
-          } else if(placeholders.heading == 'CI'){
-            icon = "⚙️"
-          }
-          return '\n#### ' + icon + ' ' + placeholders.heading + '\n';
+  "dataSource": "prs",
+  "prefix": "",
+  "onlyMilestones": false,
+  "ignoreLabels": ["closed", "automation", "enhancement", "fix",
+    "internal", "feature", "feat", "docs", "chore", "refactor", "ci",
+    "test", "Team:Automation"],
+  "groupBy": {
+      "Enhancements": ["enhancement", "internal", "feature", "feat"],
+      "Bug Fixes": ["bug", "fix"],
+      "Documentation": ["docs", "question"],
+      "No user affected": ["chore", "refactor", "perf", "test", "style", "automation"],
+      "CI": ["ci"]
+  },
+  "template": {
+      commit: ({ message, url, author, name }) => `- [${message}](${url}) - ${author ? `@${author}` : name}`,
+      issue: "- {{name}} [{{text}}]({{url}})",
+      label: "[**{{label}}**]",
+      noLabel: "closed",
+      changelogTitle: "",
+      release: "## Go {{release}}\n\n- `docker.elastic.co/beats-dev/golang-crossbuild:{{release}}-arm` - linux/arm64\n- `docker.elastic.co/beats-dev/golang-crossbuild:{{release}}-armel` - linux/armv5, linux/armv6\n- `docker.elastic.co/beats-dev/golang-crossbuild:{{release}}-armhf` - linux/armv7\n- `docker.elastic.co/beats-dev/golang-crossbuild:{{release}}-base`\n- `docker.elastic.co/beats-dev/golang-crossbuild:{{release}}-darwin` - darwin/amd64 (MacOS 10.11, MacOS 10.14)\n- `docker.elastic.co/beats-dev/golang-crossbuild:{{release}}-main` - linux/i386, linux/amd64, windows/386, windows/amd64\n- `docker.elastic.co/beats-dev/golang-crossbuild:{{release}}-main-debian7` - linux/i386, linux/amd64, windows/386, windows/amd64\n- `docker.elastic.co/beats-dev/golang-crossbuild:{{release}}-main-debian8` - linux/i386, linux/amd64, windows/386, windows/amd64\n- `docker.elastic.co/beats-dev/golang-crossbuild:{{release}}-main-debian9` - linux/i386, linux/amd64, windows/386, windows/amd64\n- `docker.elastic.co/beats-dev/golang-crossbuild:{{release}}-main-debian10` - linux/i386, linux/amd64, windows/386, windows/amd64\n- `docker.elastic.co/beats-dev/golang-crossbuild:{{release}}-mips` - linux/mips64, linux/mips64el\n- `docker.elastic.co/beats-dev/golang-crossbuild:{{release}}-mips32` - linux/mips, linux/mipsle\n- `docker.elastic.co/beats-dev/golang-crossbuild:{{release}}-ppc` - linux/ppc64, linux/ppc64le\n- `docker.elastic.co/beats-dev/golang-crossbuild:{{release}}-s390x` - linux/s390x\n{{body}}",
+      group: function (placeholders) {
+        var icon = "🙈"
+        if(placeholders.heading == 'Enhancements'){
+          icon = "🚀"
+        } else if(placeholders.heading == 'Bug Fixes'){
+          icon = "🐛"
+        } else if(placeholders.heading == 'Documentation'){
+          icon = "📚"
+        } else if(placeholders.heading == 'No user affected'){
+          icon = "🙈"
+        } else if(placeholders.heading == 'CI'){
+          icon = "⚙️"
         }
-    }
+        return '\n#### ' + icon + ' ' + placeholders.heading + '\n';
+      }
+  }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -181,8 +181,12 @@ def publishImages(){
 }
 
 def isNewRelease() {
-  // look for the GO_VERSION if matches any tag release in the project!
-  return true;
+  def releases = githubReleases()
+  if (env.GO_VERSION?.trim()) {
+    // look for the GO_VERSION if matches any tag release in the project!
+    return !releases.containsKey(env.GO_VERSION)
+  }
+  return false
 }
 
 def postRelease(){

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -131,6 +131,20 @@ pipeline {
               }
             }
           }
+          stage('Post-Release') {
+            when {
+              branch 'master'
+            }
+            environment {
+              HOME = "${env.WORKSPACE}"
+              PATH = "${env.HOME}/bin:${env.WORKSPACE}/src/.ci/scripts:${env.PATH}"
+            }
+            steps {
+              whenTrue(isNewRelease()) {
+                postRelease()
+              }
+            }
+          }
         }
       }
     }
@@ -162,6 +176,26 @@ def publishImages(){
     def platform = (PLATFORM?.trim().equals('arm')) ? '-arm' : ''
     retryWithSleep(retries: 3, seconds: 15, backoff: true) {
       sh(label: "push docker image to ${env.REPOSITORY}", script: "make -C ${GO_FOLDER} -f ${MAKEFILE} push${platform}")
+    }
+  }
+}
+
+def isNewRelease() {
+  // look for the GO_VERSION if matches any tag release in the project!
+  return true;
+}
+
+def postRelease(){
+  deleteDir()
+  unstash 'source'
+  dockerLogin(secret: "${env.DOCKER_REGISTRY_SECRET}", registry: "${env.REGISTRY}")
+  dir("${env.BASE_DIR}"){
+    sh(label: 'Set branch', script: """#!/bin/bash
+      git checkout -b ${BRANCH_NAME}
+    """)
+    gitCreateTag(tag: "${env.GO_VERSION}", pushArgs: '--force')
+    withCredentials([string(credentialsId: '2a9602aa-ab9f-4e52-baf3-b71ca88469c7', variable: 'GREN_GITHUB_TOKEN')]) {
+      sh(label: 'Creating Release Notes', script: 'release-notes.sh')
     }
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -195,7 +195,7 @@ def postRelease(){
     """)
     gitCreateTag(tag: "${env.GO_VERSION}", pushArgs: '--force')
     withCredentials([string(credentialsId: '2a9602aa-ab9f-4e52-baf3-b71ca88469c7', variable: 'GREN_GITHUB_TOKEN')]) {
-      sh(label: 'Creating Release Notes', script: 'release-notes.sh')
+      sh(label: 'Creating Release Notes', script: '.ci/scripts/release-notes.sh')
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -12,27 +12,55 @@ The base image used is Debian 9 (stretch) unless otherwise specified.
 
 `docker.elastic.co/beats-dev/golang-crossbuild:[TAG]`
 
-## Build Tags
+## Build tags
 
-| Description | Tags for 1.10 | Tags for 1.11 | Tags for 1.12 | Tags for 1.13 | Tags for 1.14 | Tags for 1.15 | Tags for 1.16 | Tags for 1.17 |
+The tags match with the Golang version, and for each supported version there is a release in https://github.com/elastic/golang-crossbuild/releases.
+
+Replace `<GOLANG_VERSION>` with the version you would like to use, for instance: `1.17.1`
+
+- `docker.elastic.co/beats-dev/golang-crossbuild:<GOLANG_VERSION>-arm` - linux/arm64
+- `docker.elastic.co/beats-dev/golang-crossbuild:<GOLANG_VERSION>-armel` - linux/armv5, linux/armv6
+- `docker.elastic.co/beats-dev/golang-crossbuild:<GOLANG_VERSION>-armhf` - linux/armv7
+- `docker.elastic.co/beats-dev/golang-crossbuild:<GOLANG_VERSION>-base`
+- `docker.elastic.co/beats-dev/golang-crossbuild:<GOLANG_VERSION>-darwin` - darwin/amd64 (MacOS 10.11, MacOS 10.14)
+- `docker.elastic.co/beats-dev/golang-crossbuild:<GOLANG_VERSION>-main` - linux/i386, linux/amd64, windows/386, windows/amd64
+- `docker.elastic.co/beats-dev/golang-crossbuild:<GOLANG_VERSION>-main-debian7` - linux/i386, linux/amd64, windows/386, windows/amd64
+- `docker.elastic.co/beats-dev/golang-crossbuild:<GOLANG_VERSION>-main-debian8` - linux/i386, linux/amd64, windows/386, windows/amd64
+- `docker.elastic.co/beats-dev/golang-crossbuild:<GOLANG_VERSION>-main-debian9` - linux/i386, linux/amd64, windows/386, windows/amd64
+- `docker.elastic.co/beats-dev/golang-crossbuild:<GOLANG_VERSION>-main-debian10` - linux/i386, linux/amd64, windows/386, windows/amd64
+- `docker.elastic.co/beats-dev/golang-crossbuild:<GOLANG_VERSION>-mips` - linux/mips64, linux/mips64el
+- `docker.elastic.co/beats-dev/golang-crossbuild:<GOLANG_VERSION>-mips32` - linux/mips, linux/mipsle
+- `docker.elastic.co/beats-dev/golang-crossbuild:<GOLANG_VERSION>-ppc` - linux/ppc64, linux/ppc64le
+- `docker.elastic.co/beats-dev/golang-crossbuild:<GOLANG_VERSION>-s390x` - linux/s390x
+
+**Debian7** uses `glibc 2.13` so the resulting binaries (if dynamically linked) have greater compatibility.
+**Debian8** uses `glibc 2.19`.
+**Debian9** uses `glibc 2.24`.
+**Debian10** uses `glibc 2.28`.
+
+## Old Build Tags
+
+Until Golang version 1.15
+
+| Description | Tags for 1.10 | Tags for 1.11 | Tags for 1.12 | Tags for 1.13 | Tags for 1.14 | Tags for 1.15 |
 | ------------- | -----| ------- | ----- |  ------ |  ------ |  ------ |  ------ |  ------ |
-| linux/{amd64,386} and windows/{amd64,386} | `1.10.8-main` | `1.11.13-main` | `1.12.12-main` |  `1.13.12-main` | `1.14.15-main` | `1.15.14-main` | `1.16.7-main` | `1.17.1-main` |
-| linux/{armv5,armv6,armv7} | `1.10.8-arm` | `1.11.13-arm` | `1.12.12-arm` | `1.13.12-arm` | `1.14.15-arm` | `1.15.14-arm` | **See below** | **See below** |
-| linux/arm64 | **See above** | **See above** | **See above** | **See above** | **See above** | **See above** | `1.16.7-arm` | `1.17.1-arm` |
-| linux/{armv5,armv6} | **See above** | **See above** | **See above** | **See above** | **See above** | **See above** | `1.16.7-armel` | `1.17.1-armel` |
-| linux/{armv7} | **See above** | **See above** | **See above** | **See above** | **See above** | **See above** | `1.16.7-armhf` | `1.17.1-armhf` |
-| darwin/{386} | `1.10.8-darwin` | `1.11.13-darwin` | `1.12.12-darwin` | `1.13.12-darwin` | `1.14.15-darwin` | `1.16.7-darwin` | `1.17.1-darwin` |
-| darwin/{amd64} | `1.10.8-darwin` | `1.11.13-darwin` | `1.12.12-darwin` | `1.13.12-darwin` | `1.14.15-darwin` | `1.16.7-darwin` | `1.17.1-darwin` |
-| linux/{ppc64,ppc64le} | `1.10.8-ppc` | `1.11.13-ppc` | `1.12.12-ppc` | `1.13.12-ppc` | `1.14.15-ppc` | `1.15.14-ppc` | `1.16.7-ppc` | `1.17.1-ppc` |
-| linux/{mips,mipsle,mips64,mips64le} | `1.10.8-mips` | `1.11.13-mips` | `1.12.12-mips` | `1.13.12-mips` | `1.14.15-mips` | `1.15.14-mips` | **See below** | **See below** |
-| linux/{mips64,mips64le} | **See above** | **See above** | **See above** | **See above** | **See above** | **See above** | `1.16.7-mips` | `1.17.1-mips` |
-| linux/{mips,mipsle} | **See above** | **See above** | **See above** | **See above** | **See above** | **See above** | `1.16.7-mips32` | `1.17.1-mips32` |
-| linux/s390x | `1.10.8-s390x` | `1.11.13-s390x` | `1.12.12-s390` | `1.13.12-s390` | `1.14.15-s390` | `1.15.14-s390` | `1.16.7-s390` | `1.17.1-s390` |
-| linux/{amd64,386} and windows/{amd64,386} (Debian 7 (see **below**)) |`1.10.8-main-debian7` | `1.11.13-main-debian7` | `1.12.12-main-debian7` | `1.13.12-main-debian7` | `1.14.15-main-debian7` | `1.15.14-main-debian7` | `1.16.7-main-debian7` | `1.17.1-main-debian7` |
-| linux/{amd64,386} and windows/{amd64,386} (Debian 8 (see **below**)) | `1.10.8-main-debian8` | `1.11.13-main-debian8` | `1.12.12-main-debian8` | `1.13.12-debian8` | `1.14.15-main-debian8` | `1.15.14-main-debian8` | `1.16.7-main-debian8` | `1.17.1-main-debian8` |
-| linux/{amd64,386} and windows/{amd64,386} (Debian 9 (see **below**)) | NA | NA | NA | NA | NA | `1.15.14-main-debian9` | `1.16.7-main-debian9` | `1.17.1-main-debian9` |
-| linux/{amd64,386} and windows/{amd64,386} (Debian 10 (see **below**)) | NA | NA | NA | NA | NA | `1.15.14-main-debian10` | `1.16.7-main-debian10` | `1.17.1-main-debian10` |
-| linux/arm64 (Debian 9 (see **below**)) | NA | NA | NA | NA | NA | `1.15.14-base-arm-debian9` | `1.16.7-base-arm-debian9` | `1.17.1-base-arm-debian` |
+| linux/{amd64,386} and windows/{amd64,386} | `1.10.8-main` | `1.11.13-main` | `1.12.12-main` |  `1.13.12-main` | `1.14.15-main` | `1.15.14-main` |
+| linux/{armv5,armv6,armv7} | `1.10.8-arm` | `1.11.13-arm` | `1.12.12-arm` | `1.13.12-arm` | `1.14.15-arm` | `1.15.14-arm` |
+| linux/arm64 | **See above** | **See above** | **See above** | **See above** | **See above** | **See above** |
+| linux/{armv5,armv6} | **See above** | **See above** | **See above** | **See above** | **See above** | **See above** |
+| linux/{armv7} | **See above** | **See above** | **See above** | **See above** | **See above** | **See above** |
+| darwin/{386} | `1.10.8-darwin` | `1.11.13-darwin` | `1.12.12-darwin` | `1.13.12-darwin` | `1.14.15-darwin` | `1.15.14-darwin` |
+| darwin/{amd64} | `1.10.8-darwin` | `1.11.13-darwin` | `1.12.12-darwin` | `1.13.12-darwin` | `1.14.15-darwin` | `1.15.14-darwin` |
+| linux/{ppc64,ppc64le} | `1.10.8-ppc` | `1.11.13-ppc` | `1.12.12-ppc` | `1.13.12-ppc` | `1.14.15-ppc` | `1.15.14-ppc` |
+| linux/{mips,mipsle,mips64,mips64le} | `1.10.8-mips` | `1.11.13-mips` | `1.12.12-mips` | `1.13.12-mips` | `1.14.15-mips` |
+| linux/{mips64,mips64le} | **See above** | **See above** | **See above** | **See above** | **See above** | **See above** |
+| linux/{mips,mipsle} | **See above** | **See above** | **See above** | **See above** | **See above** | **See above** |
+| linux/s390x | `1.10.8-s390x` | `1.11.13-s390x` | `1.12.12-s390` | `1.13.12-s390` | `1.14.15-s390` | `1.15.14-s390` |
+| linux/{amd64,386} and windows/{amd64,386} (Debian 7 (see **below**)) |`1.10.8-main-debian7` | `1.11.13-main-debian7` | `1.12.12-main-debian7` | `1.13.12-main-debian7` | `1.14.15-main-debian7` | `1.15.14-main-debian7` |
+| linux/{amd64,386} and windows/{amd64,386} (Debian 8 (see **below**)) | `1.10.8-main-debian8` | `1.11.13-main-debian8` | `1.12.12-main-debian8` | `1.13.12-debian8` | `1.14.15-main-debian8` | `1.15.14-main-debian8` |
+| linux/{amd64,386} and windows/{amd64,386} (Debian 9 (see **below**)) | NA | NA | NA | NA | NA | `1.15.14-main-debian9` |
+| linux/{amd64,386} and windows/{amd64,386} (Debian 10 (see **below**)) | NA | NA | NA | NA | NA | `1.15.14-main-debian10` |
+| linux/arm64 (Debian 9 (see **below**)) | NA | NA | NA | NA | NA | `1.15.14-base-arm-debian9` |
 
 **Debian7** uses `glibc 2.13` so the resulting binaries (if dynamically linked) have greater compatibility.
 **Debian8** uses `glibc 2.19`.


### PR DESCRIPTION
### What

Update the docker build tags:

- for Golang >= 1.16 
- Until Golang <= 1.15

Automate the changelog generation in the GitHub release section

### Actions

- [x] Verify if the tag already exists
- [x] Test

### UI

I generated locally the Changelog for testing purposes:

![image](https://user-images.githubusercontent.com/2871786/139024583-69f5ff36-fc6e-42b6-aefb-8c8ca3478849.png)


```bash
gren changelog --generate --override --token="${GREN_GITHUB_TOKEN}" -c .grenrc.js --username=elastic
🤖  - Generate changelog file:
===================================
✔ Releases found: 3
✔ Tags found: 1.17.2, 1.17.1
✔ Pull Requests found: 2
✔ Changelog created in /Users/vmartinez/work/src/github.com/elastic/golang-crossbuild/CHANGELOG.md
```

### Issues

Requires https://github.com/elastic/apm-pipeline-library/pull/1341