### PR TITLE
fix unmet dependencies for libxml2 and libxml2-dev

### DIFF
--- a/go1.16/mips/Dockerfile.tmpl
+++ b/go1.16/mips/Dockerfile.tmpl
@@ -23,6 +23,8 @@ RUN apt install -qq -y \
 {{ if eq .DEBIAN_VERSION "9" }}
 # librpm-dev
 RUN apt install -y \
+        libicu-dev:mips64el \
+        libicu57:mips64el \
         librpm-dev:mips64el \
         librpm3:mips64el \
         librpmio3:mips64el \

--- a/go1.16/mips32/Dockerfile.tmpl
+++ b/go1.16/mips32/Dockerfile.tmpl
@@ -21,6 +21,8 @@ RUN apt install -qq -y \
 {{ if eq .DEBIAN_VERSION "9" }}
 # librpm-dev
 RUN apt install -y \
+        libicu-dev:mips \
+        libicu57:mips \
         librpm-dev:mips \
         librpm3:mips \
         librpmio3:mips \

--- a/go1.16/ppc/Dockerfile.tmpl
+++ b/go1.16/ppc/Dockerfile.tmpl
@@ -19,6 +19,8 @@ RUN apt install -qq -y \
 
 {{ if eq .DEBIAN_VERSION "9" }}
 RUN apt install -qq -y \
+        libicu-dev:ppc64el \
+        libicu57:ppc64el \
         librpm-dev:ppc64el \
         libxml2-dev:ppc64el \
         libxml2:ppc64el \

--- a/go1.16/s390x/Dockerfile.tmpl
+++ b/go1.16/s390x/Dockerfile.tmpl
@@ -18,6 +18,8 @@ RUN apt install -qq -y \
 
 {{ if eq .DEBIAN_VERSION "9" }}
 RUN apt install -qq -y \
+        libicu-dev:s390x \
+        libicu57:s390x \
         librpm-dev:s390x \
         libxml2-dev:s390x \
         libxml2:s390x \

--- a/go1.17/mips/Dockerfile.tmpl
+++ b/go1.17/mips/Dockerfile.tmpl
@@ -23,6 +23,8 @@ RUN apt install -qq -y \
 {{ if eq .DEBIAN_VERSION "9" }}
 # librpm-dev
 RUN apt install -y \
+        libicu-dev:mips64el \
+        libicu57:mips64el \
         librpm-dev:mips64el \
         librpm3:mips64el \
         librpmio3:mips64el \

--- a/go1.17/mips32/Dockerfile.tmpl
+++ b/go1.17/mips32/Dockerfile.tmpl
@@ -21,6 +21,8 @@ RUN apt install -qq -y \
 {{ if eq .DEBIAN_VERSION "9" }}
 # librpm-dev
 RUN apt install -y \
+        libicu-dev:mips \
+        libicu57:mips \
         librpm-dev:mips \
         librpm3:mips \
         librpmio3:mips \

--- a/go1.17/ppc/Dockerfile.tmpl
+++ b/go1.17/ppc/Dockerfile.tmpl
@@ -19,6 +19,8 @@ RUN apt install -qq -y \
 
 {{ if eq .DEBIAN_VERSION "9" }}
 RUN apt install -qq -y \
+        libicu-dev:ppc64el \
+        libicu57:ppc64el \
         librpm-dev:ppc64el \
         libxml2-dev:ppc64el \
         libxml2:ppc64el \

--- a/go1.17/s390x/Dockerfile.tmpl
+++ b/go1.17/s390x/Dockerfile.tmpl
@@ -18,6 +18,8 @@ RUN apt install -qq -y \
 
 {{ if eq .DEBIAN_VERSION "9" }}
 RUN apt install -qq -y \
+        libicu-dev:s390x \
+        libicu57:s390x \
         librpm-dev:s390x \
         libxml2-dev:s390x \
         libxml2:s390x \


### PR DESCRIPTION
### What

Add explicitly the required dependencies for `libxml2` and `libxml2-dev` in the mips, ppc and s390x architectures

See https://packages.debian.org/stretch/libxml2-dev and https://packages.debian.org/stretch/libxml2

### Why

```
#7 1.336 The following packages have unmet dependencies:
#7 1.387  libxml2:s390x : Depends: libicu57:s390x (>= 57.1-1~) but it is not going to be installed
#7 1.387  libxml2-dev:s390x : Depends: libicu-dev:s390x but it is not going to be installed
#7 1.403 E: Unable to correct problems, you have held broken packages.
```

### Issue

Closes https://github.com/elastic/golang-crossbuild/issues/130
