### PR TITLE
fix missing deps for librpmio3 and post-release stage in the pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -131,20 +131,20 @@ pipeline {
               }
             }
           }
-          stage('Post-Release') {
-            when {
-              branch 'master'
-            }
-            environment {
-              HOME = "${env.WORKSPACE}"
-              PATH = "${env.HOME}/bin:${env.WORKSPACE}/src/.ci/scripts:${env.PATH}"
-            }
-            steps {
-              whenTrue(isNewRelease()) {
-                postRelease()
-              }
-            }
-          }
+        }
+      }
+    }
+    stage('Post-Release') {
+      when {
+        branch 'master'
+      }
+      environment {
+        HOME = "${env.WORKSPACE}"
+        PATH = "${env.HOME}/bin:${env.WORKSPACE}/src/.ci/scripts:${env.PATH}"
+      }
+      steps {
+        whenTrue(isNewRelease()) {
+          postRelease()
         }
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -181,7 +181,7 @@ def publishImages(){
 }
 
 def isNewRelease() {
-  def releases = githubReleases()
+  def releases = listGithubReleases()
   if (env.GO_VERSION?.trim()) {
     // look for the GO_VERSION if matches any tag release in the project!
     return !releases.containsKey(env.GO_VERSION)

--- a/go1.16/mips/Dockerfile.tmpl
+++ b/go1.16/mips/Dockerfile.tmpl
@@ -23,6 +23,7 @@ RUN apt install -qq -y \
 {{ if eq .DEBIAN_VERSION "9" }}
 # librpm-dev
 RUN apt install -y \
+        libelf1:mips64el \
         libicu-dev:mips64el \
         libicu57:mips64el \
         librpm-dev:mips64el \

--- a/go1.16/mips32/Dockerfile.tmpl
+++ b/go1.16/mips32/Dockerfile.tmpl
@@ -21,6 +21,7 @@ RUN apt install -qq -y \
 {{ if eq .DEBIAN_VERSION "9" }}
 # librpm-dev
 RUN apt install -y \
+        libelf1:mips \
         libicu-dev:mips \
         libicu57:mips \
         librpm-dev:mips \

--- a/go1.16/ppc/Dockerfile.tmpl
+++ b/go1.16/ppc/Dockerfile.tmpl
@@ -19,6 +19,7 @@ RUN apt install -qq -y \
 
 {{ if eq .DEBIAN_VERSION "9" }}
 RUN apt install -qq -y \
+        libelf1:ppc64el \
         libicu-dev:ppc64el \
         libicu57:ppc64el \
         librpm-dev:ppc64el \

--- a/go1.16/s390x/Dockerfile.tmpl
+++ b/go1.16/s390x/Dockerfile.tmpl
@@ -18,6 +18,7 @@ RUN apt install -qq -y \
 
 {{ if eq .DEBIAN_VERSION "9" }}
 RUN apt install -qq -y \
+        libelf1:s390x \
         libicu-dev:s390x \
         libicu57:s390x \
         librpm-dev:s390x \

--- a/go1.17/mips/Dockerfile.tmpl
+++ b/go1.17/mips/Dockerfile.tmpl
@@ -23,6 +23,7 @@ RUN apt install -qq -y \
 {{ if eq .DEBIAN_VERSION "9" }}
 # librpm-dev
 RUN apt install -y \
+        libelf1:mips64el \
         libicu-dev:mips64el \
         libicu57:mips64el \
         librpm-dev:mips64el \

--- a/go1.17/mips32/Dockerfile.tmpl
+++ b/go1.17/mips32/Dockerfile.tmpl
@@ -21,6 +21,7 @@ RUN apt install -qq -y \
 {{ if eq .DEBIAN_VERSION "9" }}
 # librpm-dev
 RUN apt install -y \
+        libelf1:mips \
         libicu-dev:mips \
         libicu57:mips \
         librpm-dev:mips \

--- a/go1.17/ppc/Dockerfile.tmpl
+++ b/go1.17/ppc/Dockerfile.tmpl
@@ -19,6 +19,7 @@ RUN apt install -qq -y \
 
 {{ if eq .DEBIAN_VERSION "9" }}
 RUN apt install -qq -y \
+        libelf1:ppc64el \
         libicu-dev:ppc64el \
         libicu57:ppc64el \
         librpm-dev:ppc64el \

--- a/go1.17/s390x/Dockerfile.tmpl
+++ b/go1.17/s390x/Dockerfile.tmpl
@@ -18,6 +18,7 @@ RUN apt install -qq -y \
 
 {{ if eq .DEBIAN_VERSION "9" }}
 RUN apt install -qq -y \
+        libelf1:s390x \
         libicu-dev:s390x \
         libicu57:s390x \
         librpm-dev:s390x \


### PR DESCRIPTION
### What

- Use top-level post-release stage rather than multiple post-release stages, since it's one task per release.
- Fix missing dependencies for the mips, ppc, s390x arch.
- Use https://github.com/elastic/apm-pipeline-library/pull/1341
