### PR TITLE
fix copy npcap

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -101,7 +101,6 @@ pipeline {
                 withGithubNotify(context: "Build ${GO_FOLDER} ${MAKEFILE} ${PLATFORM}") {
                   deleteDir()
                   unstash 'source'
-                  prepareNcap()
                   buildImages()
                 }
               }
@@ -116,7 +115,6 @@ pipeline {
                 withGithubNotify(context: "Staging ${GO_FOLDER} ${MAKEFILE} ${PLATFORM}") {
                   // It will use the already cached docker images that were created in the
                   // Build stage. But it's required to retag them with the staging repo.
-                  prepareNcap()
                   buildImages()
                   publishImages()
                 }
@@ -158,32 +156,17 @@ pipeline {
   }
 }
 
-def prepareNcap() {
-  if (PLATFORM?.trim().equals('arm')) {
-    log(level: 'INFO', text: "prepareNcap is not supported for ${PLATFORM}")
-    return
-  }
-  log(level: 'INFO', text: "prepareNcap for ${PLATFORM}")
-  withGoEnv(){
-    withGCPEnv(secret: 'secret/observability-team/ci/elastic-observability-account-auth'){
-      dir("${env.BASE_DIR}"){
-        retryWithSleep(retries: 3, seconds: 15, backoff: true) {
-          sh "make copy-npcap"
-        }
-      }
-    }
-  }
-}
-
 def buildImages(){
   log(level: 'INFO', text: "buildImages ${GO_FOLDER} with ${MAKEFILE} for ${PLATFORM}")
   withGoEnv(){
-    dir("${env.BASE_DIR}"){
-      def platform = (PLATFORM?.trim().equals('arm')) ? '-arm' : ''
-      retryWithSleep(retries: 3, seconds: 15, backoff: true) {
-        sh "make -C ${GO_FOLDER} -f ${MAKEFILE} build${platform}"
+    withGCPEnv(secret: 'secret/observability-team/ci/elastic-observability-account-auth'){
+      dir("${env.BASE_DIR}"){
+        def platform = (PLATFORM?.trim().equals('arm')) ? '-arm' : ''
+        retryWithSleep(retries: 3, seconds: 15, backoff: true) {
+          sh "make -C ${GO_FOLDER} -f ${MAKEFILE} build${platform}"
+        }
+        sh(label: 'list Docker images', script: 'docker images --format "table {{.Repository}}:{{.Tag}}\t{{.Size}}" --filter=reference="docker.elastic.co/beats-dev/golang-crossbuild"')
       }
-      sh(label: 'list Docker images', script: 'docker images --format "table {{.Repository}}:{{.Tag}}\t{{.Size}}" --filter=reference="docker.elastic.co/beats-dev/golang-crossbuild"')
     }
   }
 }

--- a/Makefile
+++ b/Makefile
@@ -3,16 +3,6 @@ include Makefile.common
 TARGETS=go1.16 go1.17
 ARM_TARGETS=go1.16 go1.17
 
-# Requires login at google storage.
-copy-npcap: status=".status.copy-npcap"
-copy-npcap:
-ifeq ($(CI),true)
-	@echo '0' > ${status}
-	$(foreach var,$(TARGETS), \
-		gsutil cp gs://obs-ci-cache/private/$(NPCAP_FILE) $(var)/npcap/lib/$(NPCAP_FILE) || echo '1' > ${status})
-else
-	@echo 'Only available if running in the CI'
-endif
 
 build: status=".status.build"
 build:

--- a/Makefile.common
+++ b/Makefile.common
@@ -8,6 +8,16 @@ NPCAP_FILE    := npcap-$(NPCAP_VERSION)-oem.exe
 SUFFIX_NPCAP_VERSION := -npcap-$(NPCAP_VERSION)
 NPCAP_REPOSITORY := docker.elastic.co/observability-ci
 
+# Requires login at google storage.
+copy-npcap: status=".status.copy-npcap"
+copy-npcap:
+	@echo '0' > ${status}
+ifeq ($(CI),true)
+	@gsutil cp gs://obs-ci-cache/private/$(NPCAP_FILE) ../npcap/lib/$(NPCAP_FILE) || echo '1' > ${status}
+else
+	@echo 'Only available if running in the CI'
+endif
+
 push:
 	$(MAKE) atomic-push
 

--- a/go1.16/Makefile.common
+++ b/go1.16/Makefile.common
@@ -9,7 +9,7 @@ TAG_EXTENSION  ?=
 
 export DEBIAN_VERSION TAG_EXTENSION
 
-build:
+build: copy-npcap
 	@echo ">> Building $(REPOSITORY)/$(NAME):$(VERSION)$(SUFFIX)$(TAG_EXTENSION)"
 	@go run $(SELF_DIR)/../template.go -t Dockerfile.tmpl -o Dockerfile
 	@docker build -t "$(REPOSITORY)/$(NAME):$(VERSION)$(SUFFIX)$(TAG_EXTENSION)" \

--- a/go1.17/Makefile.common
+++ b/go1.17/Makefile.common
@@ -9,7 +9,7 @@ TAG_EXTENSION  ?=
 
 export DEBIAN_VERSION TAG_EXTENSION
 
-build:
+build: copy-npcap
 	@echo ">> Building $(REPOSITORY)/$(NAME):$(VERSION)$(SUFFIX)$(TAG_EXTENSION)"
 	@go run $(SELF_DIR)/../template.go -t Dockerfile.tmpl -o Dockerfile
 	@docker build -t "$(REPOSITORY)/$(NAME):$(VERSION)$(SUFFIX)$(TAG_EXTENSION)" \


### PR DESCRIPTION
For some reason the toplevel Makefile did not copy in each go.1x folder the npcap but in the first one.

This will move the logic in each makefile 