### PR TITLE
Add msitools to docker beats golang-crossbuild 1.17 main image

### DIFF
--- a/go1.17/main/Dockerfile.tmpl
+++ b/go1.17/main/Dockerfile.tmpl
@@ -16,6 +16,7 @@ RUN \
         linux-libc-dev:i386 \
         mingw-w64 \
         mingw-w64-tools \
+        msitools \
         patch \
         xz-utils \
         unzip

--- a/go1.17/main/Dockerfile.tmpl
+++ b/go1.17/main/Dockerfile.tmpl
@@ -16,7 +16,6 @@ RUN \
         linux-libc-dev:i386 \
         mingw-w64 \
         mingw-w64-tools \
-        msitools \
         patch \
         xz-utils \
         unzip
@@ -31,6 +30,12 @@ RUN apt install -y --no-install-recommends --allow-unauthenticated\
 # libsystemd-dev
 RUN apt install -y --no-install-recommends --allow-unauthenticated\
          libsystemd-dev
+{{ end }}
+
+{{ if or (eq .DEBIAN_VERSION "9") (eq .DEBIAN_VERSION "10") }}
+# msitools
+RUN apt install -y --no-install-recommends --allow-unauthenticated\
+         msitools
 {{ end }}
 
 RUN rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Need to be able to extract the a file from .MSI distro for osquerybeat. 
The current workaround is installing msitools during osquerybeat build time for window platform.
Including this into the builder image would allow us to remove the workaround.

Closes: https://github.com/elastic/beats/issues/29826

Screenshot verifying the local image build msiextract tool is installed with this change:
<img width="920" alt="Screen Shot 2022-01-24 at 9 21 57 AM" src="https://user-images.githubusercontent.com/872351/150801259-db618589-5fe3-4ef0-b411-b725c66e4b8f.png">

