### PR TITLE
ci: simplify stages

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,6 +29,7 @@ pipeline {
   }
   stages {
     stage('Checkout') {
+      options { skipDefaultCheckout() }
       steps {
         deleteDir()
         gitCheckout(basedir: BASE_DIR)
@@ -36,6 +37,7 @@ pipeline {
       }
     }
     stage('Package'){
+      options { skipDefaultCheckout() }
       matrix {
         agent { label "${PLATFORM}"  }
         axes {
@@ -139,6 +141,7 @@ pipeline {
         HOME = "${env.WORKSPACE}"
         PATH = "${env.HOME}/bin:${env.WORKSPACE}/${env.BASE_DIR}/.ci/scripts:${env.PATH}"
       }
+      options { skipDefaultCheckout() }
       steps {
         whenTrue(isNewRelease()) {
           postRelease()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -121,6 +121,8 @@ pipeline {
             }
             steps {
               withGithubNotify(context: "Release ${GO_FOLDER} ${MAKEFILE} ${PLATFORM}") {
+                deleteDir()
+                unstash 'source'
                 buildImages()
                 publishImages()
               }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -95,7 +95,13 @@ pipeline {
           }
         }
         stages {
-          stage('Build') {
+          stage('Staging') {
+            when {
+              not { branch 'main' }
+            }
+            environment {
+              REPOSITORY = "${env.STAGING_IMAGE}"
+            }
             steps {
               stageStatusCache(id: "Build ${GO_FOLDER} ${MAKEFILE} ${PLATFORM}") {
                 withGithubNotify(context: "Build ${GO_FOLDER} ${MAKEFILE} ${PLATFORM}") {
@@ -103,19 +109,7 @@ pipeline {
                   unstash 'source'
                   buildImages()
                 }
-              }
-            }
-          }
-          stage('Staging') {
-            environment {
-              REPOSITORY = "${env.STAGING_IMAGE}"
-            }
-            steps {
-              stageStatusCache(id: "Staging ${GO_FOLDER} ${MAKEFILE} ${PLATFORM}") {
                 withGithubNotify(context: "Staging ${GO_FOLDER} ${MAKEFILE} ${PLATFORM}") {
-                  // It will use the already cached docker images that were created in the
-                  // Build stage. But it's required to retag them with the staging repo.
-                  buildImages()
                   publishImages()
                 }
               }
@@ -127,6 +121,7 @@ pipeline {
             }
             steps {
               withGithubNotify(context: "Release ${GO_FOLDER} ${MAKEFILE} ${PLATFORM}") {
+                buildImages()
                 publishImages()
               }
             }


### PR DESCRIPTION
### What

Merge the `build` and `staging` stages and use GitHub checks to notify if any failure.

### Why

Reduce the changes of rebuilding to be able to retag the images.