### PR TITLE
build-and-publish multi-architecture docker images

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -118,6 +118,7 @@ def buildImages(){
     withGCPEnv(secret: 'secret/observability-team/ci/elastic-observability-account-auth'){
       dir("${env.BASE_DIR}"){
         def platform = (PLATFORM?.trim().equals('arm')) ? '-arm' : ''
+        sh(label: 'make prepare-buildx', script: 'make prepare-buildx')
         retryWithSleep(retries: 3, seconds: 15, backoff: true) {
           sh "make -C ${GO_FOLDER} -f ${MAKEFILE} build${platform}"
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@ pipeline {
     REGISTRY = 'docker.elastic.co'
     STAGING_IMAGE = "${env.REGISTRY}/observability-ci"
     GO_VERSION = '1.17.7'
-    DOCKER_BUILD = 'docker buildx build --platform linux/amd64,linux/arm64,linux/arm/v7 --push'
+    DOCKER_BUILD = 'docker buildx build --platform linux/amd64,linux/arm64 --push'
   }
   options {
     timeout(time: 3, unit: 'HOURS')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -48,53 +48,11 @@ pipeline {
           }
           axis {
             name 'GO_FOLDER'
-            values 'go1.16', 'go1.17'
+            values 'go1.17'
           }
           axis {
             name 'PLATFORM'
-            values 'ubuntu-20 && immutable', 'arm'
-          }
-        }
-        excludes {
-          exclude {
-            axis {
-              name 'PLATFORM'
-              values 'arm'
-            }
-            axis {
-              name 'MAKEFILE'
-              values 'Makefile'
-            }
-          }
-          exclude {
-            axis {
-              name 'PLATFORM'
-              values 'arm'
-            }
-            axis {
-              name 'MAKEFILE'
-              values 'Makefile.debian7'
-            }
-          }
-          exclude {
-            axis {
-              name 'PLATFORM'
-              values 'arm'
-            }
-            axis {
-              name 'MAKEFILE'
-              values 'Makefile.debian8'
-            }
-          }
-          exclude {
-            axis {
-              name 'PLATFORM'
-              values 'arm'
-            }
-            axis {
-              name 'MAKEFILE'
-              values 'Makefile.debian10'
-            }
+            values 'ubuntu-20 && immutable'
           }
         }
         stages {

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ prepare-buildx:
 	@echo '0' > ${status}
 	@docker buildx ls || echo '1' > ${status}
 	@docker buildx rm golangcrossbuild || true
-	@docker buildx create --name golangcrossbuild --use || echo '1' > ${status}
+	@docker buildx create --name golangcrossbuild --platform linux/amd64,linux/arm64 --use || echo '1' > ${status}
 	@docker buildx inspect --bootstrap || echo '1' > ${status}
 	exit $$(cat ${status})
 

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,14 @@ include Makefile.common
 TARGETS=go1.16 go1.17
 ARM_TARGETS=go1.16 go1.17
 
+prepare-buildx: status=".status.prepare.buildx"
+prepare-buildx:
+	@echo '0' > ${status}
+	@docker buildx ls || echo '1' > ${status}
+	@docker buildx rm golangcrossbuild || true
+	@docker buildx create --name golangcrossbuild --use || echo '1' > ${status}
+	@docker buildx inspect --bootstrap || echo '1' > ${status}
+	exit $$(cat ${status})
 
 build: status=".status.build"
 build:
@@ -47,4 +55,4 @@ push-arm:
 	@make -C fpm $@ || echo '1' > ${status}
 	exit $$(cat ${status})
 
-.PHONY: build build-arm push push-arm
+.PHONY: build build-arm push push-arm prepare-buildx

--- a/go1.17/Makefile.common
+++ b/go1.17/Makefile.common
@@ -7,12 +7,14 @@ DEBIAN_VERSION ?= 9
 SUFFIX         := -$(shell basename $(CURDIR))
 TAG_EXTENSION  ?=
 
+DOCKER_BUILD ?= docker build
+
 export DEBIAN_VERSION TAG_EXTENSION
 
 build: copy-npcap
 	@echo ">> Building $(REPOSITORY)/$(NAME):$(VERSION)$(SUFFIX)$(TAG_EXTENSION)"
 	@go run $(SELF_DIR)/../template.go -t Dockerfile.tmpl -o Dockerfile
-	@docker build -t "$(REPOSITORY)/$(NAME):$(VERSION)$(SUFFIX)$(TAG_EXTENSION)" \
+	@$(DOCKER_BUILD) -t "$(REPOSITORY)/$(NAME):$(VERSION)$(SUFFIX)$(TAG_EXTENSION)" \
 	--build-arg REPOSITORY=$(REPOSITORY) \
 	--build-arg VERSION=$(VERSION) \
 	--build-arg DEBIAN_VERSION=$(DEBIAN_VERSION) \


### PR DESCRIPTION
### what

Use https://docs.docker.com/desktop/multi-arch/#build-and-run-multi-architecture-images 

### Implementation details

- Remove support for `go1.16`
- Remove `aarch64` workers in favour of the buildx
- Remove `publish` stage in favour of the `--push` flag for the `buildx` 
- Use the platforms `linux/amd64,linux/arm64,linux/arm/v7`
- Keep the default behaviour with `docker build` and leverage the CI pipeline to override the default behaviour with the env variable `DOCKER_BUILD`.


