### PR TITLE
mergify: support backport policy

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -10,3 +10,95 @@ pull_request_rules:
         - files~=^Jenkinsfile$
     actions:
       delete_head_branch:
+  - name: ask to resolve conflict
+    conditions:
+      - -merged
+      - -closed
+      - conflict
+      - -author=apmmachine
+    actions:
+        comment:
+          message: |
+            This pull request is now in conflicts. Could you fix it? 🙏
+            To fixup this pull request, you can check out it locally. See documentation: https://help.github.com/articles/checking-out-pull-requests-locally/
+            ```
+            git fetch upstream
+            git checkout -b {{head}} upstream/{{head}}
+            git merge upstream/{{base}}
+            git push upstream {{head}}
+            ```
+  - name: close automated pull requests with bump updates if any conflict
+    conditions:
+      - -merged
+      - -closed
+      - conflict
+      - author=apmmachine
+      - label=automation
+    actions:
+      close:
+        message: |
+          This pull request has been automatically closed by Mergify.
+          There are some other up-to-date pull requests.
+  - name: notify the backport has not been merged yet
+    conditions:
+      - -merged
+      - -closed
+      - author=mergify[bot]
+      - "#check-success>0"
+      - schedule=Mon-Mon 06:00-10:00[Europe/Paris]
+    actions:
+      comment:
+        message: |
+          This pull request has not been merged yet. Could you please review and merge it @{{ assignee | join(', @') }}? 🙏
+  - name: notify the backport policy
+    conditions:
+      - -label~=^backport
+      - base=main
+      - -merged
+      - -closed
+    actions:
+      comment:
+        message: |
+          This pull request does not have a backport label. Could you fix it @{{author}}? 🙏
+          To fixup this pull request, you need to add the backport labels for the needed
+          branches, such as:
+          * `backport-v./d./d` is the label to automatically backport to the `1./d` branch. `/d` is the digit
+          **NOTE**: `backport-skip` has been added to this pull request.
+      label:
+        add:
+          - backport-skip
+  - name: remove-backport label
+    conditions:
+      - label~=backport-v
+      - -merged
+      - -closed
+    actions:
+      label:
+        remove:
+          - backport-skip
+  - name: backport patches to 1.16 branch
+    conditions:
+      - merged
+      - label=backport-v1.16
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        branches:
+          - "1.16"
+        labels:
+          - "backport"
+        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
+  - name: backport patches to 1.17 branch
+    conditions:
+      - merged
+      - label=backport-v1.17
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        branches:
+          - "1.17"
+        labels:
+          - "backport"
+        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"


### PR DESCRIPTION
### What

Use mergify for:
- Notify conflicts
- Notify backports that have not been updated for > 1 week
- Enable backports based on labels 
- Notify the backport policy
- Tidy up PRs if they got conflict and they were automatically created. 