### PR TITLE
[automation] Update go release version 1.17.9

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
     DOCKER_REGISTRY_SECRET = 'secret/observability-team/ci/docker-registry/prod'
     REGISTRY = 'docker.elastic.co'
     STAGING_IMAGE = "${env.REGISTRY}/observability-ci"
-    GO_VERSION = '1.17.8'
+    GO_VERSION = '1.17.9'
   }
   options {
     timeout(time: 3, unit: 'HOURS')

--- a/go/Makefile.common
+++ b/go/Makefile.common
@@ -2,7 +2,7 @@ SELF_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 include $(SELF_DIR)/../Makefile.common
 
 NAME           := golang-crossbuild
-VERSION        := 1.17.8
+VERSION        := 1.17.9
 DEBIAN_VERSION ?= 9
 SUFFIX         := -$(shell basename $(CURDIR))
 TAG_EXTENSION  ?=

--- a/go/base-arm/Dockerfile.tmpl
+++ b/go/base-arm/Dockerfile.tmpl
@@ -37,9 +37,9 @@ RUN \
             libsqlite3-0 \
         && rm -rf /var/lib/apt/lists/*
 
-ARG GOLANG_VERSION=1.17.8
+ARG GOLANG_VERSION=1.17.9
 ARG GOLANG_DOWNLOAD_URL=https://golang.org/dl/go$GOLANG_VERSION.linux-arm64.tar.gz
-ARG GOLANG_DOWNLOAD_SHA256=57a9171682e297df1a5bd287be056ed0280195ad079af90af16dcad4f64710cb
+ARG GOLANG_DOWNLOAD_SHA256=44dcdcd4f0fa6f83c15ef70b31580f1e3f95895c2f11a00e36c440c3554b6ad5
 
 RUN curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz \
 	&& echo "$GOLANG_DOWNLOAD_SHA256  golang.tar.gz" | sha256sum -c - \

--- a/go/base/Dockerfile.tmpl
+++ b/go/base/Dockerfile.tmpl
@@ -29,9 +29,9 @@ RUN apt-get -o Acquire::Check-Valid-Until=false update -y --no-install-recommend
 RUN ln -s /usr/bin/pip3 /usr/bin/pip
 {{ end }}
 
-ARG GOLANG_VERSION=1.17.8
+ARG GOLANG_VERSION=1.17.9
 ARG GOLANG_DOWNLOAD_URL=https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
-ARG GOLANG_DOWNLOAD_SHA256=980e65a863377e69fd9b67df9d8395fd8e93858e7a24c9f55803421e453f4f99
+ARG GOLANG_DOWNLOAD_SHA256=9dacf782028fdfc79120576c872dee488b81257b1c48e9032d122cfdb379cca6
 
 RUN curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz \
 	&& echo "$GOLANG_DOWNLOAD_SHA256  golang.tar.gz" | sha256sum -c - \


### PR DESCRIPTION
### What 
 Bump go release version with the latest release. 
 ### Further details 
 See [changelog](https://github.com/golang/go/issues?q=milestone%3AGo1.17.9+label%3ACherryPickApproved) for 1.17.9