### PR TITLE
Correct unmet dependencies on mips, mips32, ppc and s390x #173

### DIFF
--- a/go/mips/Dockerfile.tmpl
+++ b/go/mips/Dockerfile.tmpl
@@ -22,7 +22,7 @@ RUN apt install -qq -y \
 
 {{ if eq .DEBIAN_VERSION "9" }}
 # librpm-dev
-RUN apt install -y \
+RUN apt install -y --allow-downgrades \
         libelf1:mips64el \
         libicu-dev:mips64el \
         libicu57:mips64el \
@@ -36,7 +36,9 @@ RUN apt install -y \
         libnss3:mips64el \
         libsqlite3-0:mips64el \
         libxml2:mips64el \
-        libsqlite3-0:mips64el
+        libsqlite3-0:mips64el \
+        liblzma5:amd64=5.2.2-1.2+b1 \
+        zlib1g:amd64=1:1.2.8.dfsg-5
 
 # libsystemd-dev
 # RUN apt install -y \

--- a/go/mips32/Dockerfile.tmpl
+++ b/go/mips32/Dockerfile.tmpl
@@ -20,7 +20,7 @@ RUN apt install -qq -y \
 
 {{ if eq .DEBIAN_VERSION "9" }}
 # librpm-dev
-RUN apt install -y \
+RUN apt install -y --allow-downgrades \
         libelf1:mips \
         libicu-dev:mips \
         libicu57:mips \
@@ -34,7 +34,9 @@ RUN apt install -y \
         libnss3:mips \
         libsqlite3-0:mips \
         libxml2:mips \
-        libsqlite3-0:mips
+        libsqlite3-0:mips \
+        liblzma5:amd64=5.2.2-1.2+b1 \
+        zlib1g:amd64=1:1.2.8.dfsg-5
 
 # libsystemd-dev
 # RUN apt install -y \

--- a/go/ppc/Dockerfile.tmpl
+++ b/go/ppc/Dockerfile.tmpl
@@ -18,7 +18,7 @@ RUN apt install -qq -y \
         linux-libc-dev:ppc64el
 
 {{ if eq .DEBIAN_VERSION "9" }}
-RUN apt install -qq -y \
+RUN apt install -qq -y --allow-downgrades \
         libelf1:ppc64el \
         libicu-dev:ppc64el \
         libicu57:ppc64el \
@@ -31,7 +31,9 @@ RUN apt install -qq -y \
         librpmsign3:ppc64el \
         libsqlite3-dev:ppc64el \
         libnss3:ppc64el \
-        libsqlite3-0:ppc64el
+        libsqlite3-0:ppc64el \
+        liblzma5:amd64=5.2.2-1.2+b1 \
+        zlib1g:amd64=1:1.2.8.dfsg-5
 
 # RUN apt install -y \
 #         libsystemd-dev:ppc64el libsystemd0:ppc64el liblz4-1:ppc64el

--- a/go/s390x/Dockerfile.tmpl
+++ b/go/s390x/Dockerfile.tmpl
@@ -17,7 +17,7 @@ RUN apt install -qq -y \
         linux-libc-dev:s390x
 
 {{ if eq .DEBIAN_VERSION "9" }}
-RUN apt install -qq -y \
+RUN apt install -qq -y --allow-downgrades \
         libelf1:s390x \
         libicu-dev:s390x \
         libicu57:s390x \
@@ -30,7 +30,9 @@ RUN apt install -qq -y \
         librpmsign3:s390x \
         libsqlite3-dev:s390x \
         libnss3:s390x \
-        libsqlite3-0:s390x
+        libsqlite3-0:s390x \
+        liblzma5:amd64=5.2.2-1.2+b1 \
+        zlib1g:amd64=1:1.2.8.dfsg-5
 
 # RUN apt install -y \
 #         libsystemd-dev:s390x libsystemd0:s390x liblz4-1:s390x


### PR DESCRIPTION
Resolve issue #173 by downgrading [zlib1g](https://packages.debian.org/stretch/zlib1g) and [liblzma5](https://packages.debian.org/stretch/liblzma5) to a previous version.

Signed-off-by: Adrien Mannocci <adrien.mannocci@elastic.co>