### PR TITLE
fix: remove support for debian 9 on mips mips32 ppc s390x

### DIFF
--- a/go/Makefile
+++ b/go/Makefile
@@ -1,17 +1,3 @@
-IMAGES := base main darwin arm armhf armel mips mips32 ppc s390x npcap
-ARM_IMAGES := base-arm
+include ./Makefile.debian9
 
-build:
-	@$(foreach var,$(IMAGES),$(MAKE) -C $(var) build || exit 1;)
-
-build-arm:
-	@$(foreach var,$(ARM_IMAGES),$(MAKE) -C $(var) build-arm || exit 1;)
-
-# Requires login at https://docker.elastic.co:7000/.
-push:
-	@$(foreach var,$(IMAGES),$(MAKE) -C $(var) push || exit 1;)
-
-push-arm:
-	@$(foreach var,$(ARM_IMAGES),$(MAKE) -C $(var) push-arm || exit 1;)
-
-.PHONY: build build-arm push push-arm
+TAG_EXTENSION  := ""

--- a/go/Makefile.debian9
+++ b/go/Makefile.debian9
@@ -1,4 +1,4 @@
-IMAGES         := base main darwin arm armhf armel mips mips32 ppc s390x npcap
+IMAGES         := base main darwin arm armhf armel npcap
 ARM_IMAGES     := base-arm
 DEBIAN_VERSION := 9
 TAG_EXTENSION  := -debian9


### PR DESCRIPTION
Remove support for Debian 9 on mips mips32 ppc s390x. Recent changes on the `librpm-dev` package in Debian 9 have broken the way we install this library for cross compile, due to we have support on Debian 10 that works fine for those architectures we remove support for them on Debian 9.


closes https://github.com/elastic/golang-crossbuild/issues/173