### PR TITLE
docs: debian 10 support only for some platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ needed when the application uses [cgo](https://golang.org/cmd/cgo/).
 
 The base image used is Debian 9 (stretch) unless otherwise specified.
 
+`mips`, `mips32`, `ppc`, `s390x` and `darwin-arm64` are only based on `Debian 10`.
+
 ## Docker Repo
 
 `docker.elastic.co/beats-dev/golang-crossbuild:[TAG]`


### PR DESCRIPTION
As agreed in https://github.com/elastic/golang-crossbuild/issues/173 some platforms are not anymore supported for `Debian9` but `Debian10` instead.
