### PR TITLE
Support Debian 11

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,7 +43,7 @@ pipeline {
         axes {
           axis {
             name 'MAKEFILE'
-            values 'Makefile', 'Makefile.debian7', 'Makefile.debian8', 'Makefile.debian9', 'Makefile.debian10'
+            values 'Makefile', 'Makefile.debian7', 'Makefile.debian8', 'Makefile.debian9', 'Makefile.debian10', 'Makefile.debian11'
           }
           axis {
             name 'PLATFORM'
@@ -89,6 +89,16 @@ pipeline {
             axis {
               name 'MAKEFILE'
               values 'Makefile.debian10'
+            }
+          }
+          exclude {
+            axis {
+              name 'PLATFORM'
+              values 'arm'
+            }
+            axis {
+              name 'MAKEFILE'
+              values 'Makefile.debian11'
             }
           }
         }

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,8 @@ build:
 		$(MAKE) -C $(var) -f Makefile.debian7 $@ || echo '1' > ${status}; \
 		$(MAKE) -C $(var) -f Makefile.debian8 $@ || echo '1' > ${status}; \
 		$(MAKE) -C $(var) -f Makefile.debian9 $@ || echo '1' > ${status}; \
-		$(MAKE) -C $(var) -f Makefile.debian10 $@ || echo '1' > ${status})
+		$(MAKE) -C $(var) -f Makefile.debian10 $@ || echo '1' > ${status}; \
+		$(MAKE) -C $(var) -f Makefile.debian11 $@ || echo '1' > ${status})
 	@make -C fpm $@ || echo '1' > ${status}
 	exit $$(cat ${status})
 
@@ -34,7 +35,8 @@ push:
 		$(MAKE) -C $(var) -f Makefile.debian7 $@ || echo '1' > ${status}; \
 		$(MAKE) -C $(var) -f Makefile.debian8 $@ || echo '1' > ${status}; \
 		$(MAKE) -C $(var) -f Makefile.debian9 $@ || echo '1' > ${status}; \
-		$(MAKE) -C $(var) -f Makefile.debian10 $@ || echo '1' > ${status})
+		$(MAKE) -C $(var) -f Makefile.debian10 $@ || echo '1' > ${status}; \
+		$(MAKE) -C $(var) -f Makefile.debian11 $@ || echo '1' > ${status})
 	@make -C fpm $@ || echo '1' > ${status}
 	exit $$(cat ${status})
 

--- a/go/Makefile.debian11
+++ b/go/Makefile.debian11
@@ -1,0 +1,14 @@
+IMAGES         := base main darwin arm armhf armel mips mips32 ppc s390x darwin-arm64 npcap
+DEBIAN_VERSION := 11
+TAG_EXTENSION  := -debian11
+
+export DEBIAN_VERSION TAG_EXTENSION
+
+build:
+	@$(foreach var,$(IMAGES),$(MAKE) -C $(var) build || exit 1;)
+
+# Requires login at https://docker.elastic.co:7000/.
+push:
+	@$(foreach var,$(IMAGES),$(MAKE) -C $(var) push || exit 1;)
+
+.PHONY: build push

--- a/go/Makefile.debian11
+++ b/go/Makefile.debian11
@@ -1,4 +1,4 @@
-IMAGES         := base main darwin arm armhf armel mips mips32 ppc s390x darwin-arm64 npcap
+IMAGES         := base main darwin arm armhf armel ppc s390x darwin-arm64 npcap
 DEBIAN_VERSION := 11
 TAG_EXTENSION  := -debian11
 

--- a/go/arm/Dockerfile.tmpl
+++ b/go/arm/Dockerfile.tmpl
@@ -36,7 +36,7 @@ RUN apt install -y \
         libsystemd-dev:arm64 libsystemd0:arm64 liblz4-1:arm64
 {{ end }}
 
-{{if eq .DEBIAN_VERSION "10"}}
+{{if or (eq .DEBIAN_VERSION "10") (eq .DEBIAN_VERSION "11")}}
 # librpm-dev
 RUN apt install -y \
         librpm-dev:arm64

--- a/go/armel/Dockerfile.tmpl
+++ b/go/armel/Dockerfile.tmpl
@@ -36,7 +36,7 @@ RUN apt install -y \
         libsystemd-dev:armel libsystemd0:armel liblz4-1:armel
 {{ end }}
 
-{{if eq .DEBIAN_VERSION "10"}}
+{{if or (eq .DEBIAN_VERSION "10") (eq .DEBIAN_VERSION "11")}}
 # librpm-dev
 RUN apt install -y \
         librpm-dev:armel

--- a/go/armhf/Dockerfile.tmpl
+++ b/go/armhf/Dockerfile.tmpl
@@ -36,7 +36,7 @@ RUN apt install -y \
         libsystemd-dev:armhf libsystemd0:armhf liblz4-1:armhf
 {{ end }}
 
-{{if eq .DEBIAN_VERSION "10"}}
+{{if or (eq .DEBIAN_VERSION "10") (eq .DEBIAN_VERSION "11")}}
 # librpm-dev
 RUN apt install -y \
         librpm-dev:armhf

--- a/go/base/Dockerfile.tmpl
+++ b/go/base/Dockerfile.tmpl
@@ -18,7 +18,7 @@ RUN apt-get -o Acquire::Check-Valid-Until=false update -y --no-install-recommend
             file \
             flex \
             bison \
-{{if eq .DEBIAN_VERSION "10"}}
+{{if or (eq .DEBIAN_VERSION "10") (eq .DEBIAN_VERSION "11")}}
             python3-venv \
             python3-pip \
             python3 \

--- a/go/base/sources-debian11.list
+++ b/go/base/sources-debian11.list
@@ -1,0 +1,3 @@
+# see https://wiki.debian.org/CrossToolchains
+deb http://deb.debian.org/debian bullseye main
+deb http://deb.debian.org/debian-security/ bullseye-security main

--- a/go/darwin-arm64/Dockerfile.tmpl
+++ b/go/darwin-arm64/Dockerfile.tmpl
@@ -14,7 +14,7 @@ RUN \
         uuid-dev \
     && rm -rf /var/lib/apt/lists/*
 
-{{if eq .DEBIAN_VERSION "10"}}
+{{if or (eq .DEBIAN_VERSION "10") (eq .DEBIAN_VERSION "11")}}
 ARG OSXCROSS_SDK_URL=https://storage.googleapis.com/obs-ci-cache/beats/MacOSX11.3.sdk.tar.xz
 ARG OSXCROSS_PATH=/usr/osxcross
 ARG OSXCROSS_REV=035cc170338b7b252e3f13b0e3ccbf4411bffc41

--- a/go/darwin/Dockerfile.tmpl
+++ b/go/darwin/Dockerfile.tmpl
@@ -10,7 +10,7 @@ RUN \
         llvm \
         cmake \
         patch \
-{{if ne .DEBIAN_VERSION "10"}}
+{{if and (ne .DEBIAN_VERSION "10") (ne .DEBIAN_VERSION "11")}}
         python \
 {{ end }}
         libssl-dev \
@@ -20,7 +20,7 @@ RUN \
         uuid-dev \
     && rm -rf /var/lib/apt/lists/*
 
-{{if eq .DEBIAN_VERSION "10"}}
+{{if or (eq .DEBIAN_VERSION "10") (eq .DEBIAN_VERSION "11")}}
 ARG OSXCROSS_SDK_URL=https://storage.googleapis.com/obs-ci-cache/beats/MacOSX10.14.sdk.tar.xz
 ARG OSXCROSS_PATH=/usr/osxcross
 ARG OSXCROSS_REV=8a716a43a72dab1db9630d7824ee0af3730cb8f9
@@ -58,7 +58,7 @@ RUN cd / \
   && file helloWorld | grep -c 'Mach-O 64-bit x86_64'
 
 # MacOSX10.14 SDK does not have 32bits compiler
-{{if ne .DEBIAN_VERSION "10"}}
+{{if and (ne .DEBIAN_VERSION "10") (ne .DEBIAN_VERSION "11")}}
 RUN cd / \
   && o32-clang helloWorld.c -o helloWorld \
   && file helloWorld \

--- a/go/main/Dockerfile.tmpl
+++ b/go/main/Dockerfile.tmpl
@@ -20,7 +20,7 @@ RUN \
         xz-utils \
         unzip
 
-{{ if neq .DEBIAN_VERSION "7" }}
+{{ if ne .DEBIAN_VERSION "7" }}
 # librpm-dev
 RUN apt install -y --no-install-recommends --allow-unauthenticated\
         librpm-dev \

--- a/go/main/Dockerfile.tmpl
+++ b/go/main/Dockerfile.tmpl
@@ -20,7 +20,7 @@ RUN \
         xz-utils \
         unzip
 
-{{ if or (eq .DEBIAN_VERSION "8") (eq .DEBIAN_VERSION "9") (eq .DEBIAN_VERSION "10") }}
+{{ if neq .DEBIAN_VERSION "7" }}
 # librpm-dev
 RUN apt install -y --no-install-recommends --allow-unauthenticated\
         librpm-dev \
@@ -32,7 +32,7 @@ RUN apt install -y --no-install-recommends --allow-unauthenticated\
          libsystemd-dev
 {{ end }}
 
-{{ if or (eq .DEBIAN_VERSION "9") (eq .DEBIAN_VERSION "10") }}
+{{ if or (eq .DEBIAN_VERSION "9") (eq .DEBIAN_VERSION "10") (eq .DEBIAN_VERSION "11") }}
 # msitools
 RUN apt install -y --no-install-recommends --allow-unauthenticated\
          msitools

--- a/go/mips/Dockerfile.tmpl
+++ b/go/mips/Dockerfile.tmpl
@@ -43,7 +43,7 @@ RUN apt install -y \
 #         libsystemd-dev:mips64el libsystemd0:mips64el liblz4-1:mips64el
 {{ end }}
 
-{{if eq .DEBIAN_VERSION "10"}}
+{{if or (eq .DEBIAN_VERSION "10") (eq .DEBIAN_VERSION "11")}}
 # librpm-dev
 RUN apt install -y \
         librpm-dev:mips64el

--- a/go/mips32/Dockerfile.tmpl
+++ b/go/mips32/Dockerfile.tmpl
@@ -41,7 +41,7 @@ RUN apt install -y \
 #         libsystemd-dev:mips libsystemd0:mips liblz4-1:mips
 {{ end }}
 
-{{if eq .DEBIAN_VERSION "10"}}
+{{if or (eq .DEBIAN_VERSION "10") (eq .DEBIAN_VERSION "11")}}
 # librpm-dev
 RUN apt install -y \
         librpm-dev:mips

--- a/go/ppc/Dockerfile.tmpl
+++ b/go/ppc/Dockerfile.tmpl
@@ -37,7 +37,7 @@ RUN apt install -qq -y \
 #         libsystemd-dev:ppc64el libsystemd0:ppc64el liblz4-1:ppc64el
 {{ end }}
 
-{{if eq .DEBIAN_VERSION "10"}}
+{{if or (eq .DEBIAN_VERSION "10") (eq .DEBIAN_VERSION "11")}}
 # librpm-dev
 RUN apt install -y \
         librpm-dev:ppc64el

--- a/go/s390x/Dockerfile.tmpl
+++ b/go/s390x/Dockerfile.tmpl
@@ -36,7 +36,7 @@ RUN apt install -qq -y \
 #         libsystemd-dev:s390x libsystemd0:s390x liblz4-1:s390x
 {{ end }}
 
-{{if eq .DEBIAN_VERSION "10"}}
+{{if or (eq .DEBIAN_VERSION "10") (eq .DEBIAN_VERSION "11")}}
 # librpm-dev
 RUN apt install -y \
         librpm-dev:s390x


### PR DESCRIPTION
## What

Add support for `Debian 11`


## Further details


Some packages are not available for `mips` in `bullseye`, so I removed them from the list of supported platforms for Debian 11.

https://packages.debian.org/bullseye/libc6-dev is the package that failed to be found


## Issues

Closes https://github.com/elastic/golang-crossbuild/issues/178