### PR TITLE
chore: move golang crossbuild job to a dedicated folder

### DIFF
--- a/.ci/jobs/golang-crossbuild-mbp.yml
+++ b/.ci/jobs/golang-crossbuild-mbp.yml
@@ -1,6 +1,6 @@
 ---
 - job:
-    name: Beats/golang-crossbuild-mbp
+    name: golang-crossbuild/golang-crossbuild-mbp
     display-name: Pipeline for golang-crossbuild
     description: Jenkins pipeline for the golang-crossbuild project.
     view: Beats

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,22 @@
 
+#!/usr/bin/env groovy
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 @Library('apm@current') _
 
 pipeline {


### PR DESCRIPTION
move golang crossbuild job to a dedicated folder