### PR TITLE
fix: add TAG_EXTENSION to use the right base images

### DIFF
--- a/.ci/llvm-apple.groovy
+++ b/.ci/llvm-apple.groovy
@@ -58,6 +58,7 @@ pipeline {
                 environment {
                     DEBIAN_VERSION = "10"
                     MAKEFILE = "go/llvm-apple"
+                    TAG_EXTENSION = "-debian10"
                 }
                 options { skipDefaultCheckout() }
                 steps {


### PR DESCRIPTION
Only Debian 10 is supported, LLVM needs Python installed