### PR TITLE
chore: remove Go version from the LLVM image tag

### DIFF
--- a/.ci/llvm-apple.groovy
+++ b/.ci/llvm-apple.groovy
@@ -44,7 +44,7 @@ pipeline {
     stage('Check changes'){
       when {
         anyOf {
-          changelog '/go/llvm-apple/**'
+          changelog '/go/llvm-apple/*'
           changelog '.ci/llvm-apple.groovy'
           changeset '/go/llvm-apple/**'
           changeset '.ci/llvm-apple.groovy'

--- a/.ci/llvm-apple.groovy
+++ b/.ci/llvm-apple.groovy
@@ -44,8 +44,10 @@ pipeline {
     stage('Check changes'){
       when {
         anyOf {
-          changelog pattern: '/go/llvm-apple/*'
-          changelog pattern: '.ci/llvm-apple.groovy'
+          changelog '/go/llvm-apple/**'
+          changelog '.ci/llvm-apple.groovy'
+          changeset '/go/llvm-apple/**'
+          changeset '.ci/llvm-apple.groovy'
           expression { return isUserTrigger() }
         }
       }

--- a/.ci/llvm-apple.groovy
+++ b/.ci/llvm-apple.groovy
@@ -76,6 +76,9 @@ pipeline {
                 options { skipDefaultCheckout() }
                 steps {
                   stageStatusCache(id: "Build ${MAKEFILE}") {
+                    whenTrue(isPR()){
+                      setEnvVar("REPOSITORY", "${env.STAGING_IMAGE}")
+                    }
                     withGithubNotify(context: "Build ${MAKEFILE}") {
                       deleteDir()
                       unstash 'source'

--- a/.ci/llvm-apple.groovy
+++ b/.ci/llvm-apple.groovy
@@ -41,6 +41,62 @@ pipeline {
     quietPeriod(10)
   }
   stages {
+    stage('before checkout when changelog'){
+      when {
+        changelog '.ci/llvm-apple.groovy'
+      }
+      steps {
+        echo 'before checkout when changelog'
+      }
+    }
+    stage('before checkout when changeset'){
+      when {
+        changeset '.ci/llvm-apple.groovy'
+      }
+      steps {
+        echo 'before checkout when changeset'
+      }
+    }
+    stage('before checkout when isGitRegionMatch'){
+      when {
+        expression {  return isGitRegionMatch(patterns: ['^\\.ci/llvm-apple.groovy', '^/go/llvm-apple'], shouldMatchAll: false) }
+      }
+      steps {
+        echo 'before checkout when isGitRegionMatch'
+      }
+    }
+    stage('Checkout') {
+      options { skipDefaultCheckout() }
+      steps {
+          deleteDir()
+          gitCheckout(basedir: BASE_DIR)
+          stash name: 'source', useDefaultExcludes: false
+      }
+    }
+    stage('when changelog'){
+      when {
+        changelog '.ci/llvm-apple.groovy'
+      }
+      steps {
+        echo 'when changelog'
+      }
+    }
+    stage('when changeset'){
+      when {
+        changeset '.ci/llvm-apple.groovy'
+      }
+      steps {
+        echo 'when changeset'
+      }
+    }
+    stage('when isGitRegionMatch'){
+      when {
+        expression {  return isGitRegionMatch(patterns: ['^\\.ci/llvm-apple.groovy', '^/go/llvm-apple'], shouldMatchAll: false) }
+      }
+      steps {
+        echo 'when isGitRegionMatch'
+      }
+    }
     stage('Check changes'){
       when {
         anyOf {
@@ -53,14 +109,6 @@ pipeline {
         }
       }
       stages {
-        stage('Checkout') {
-            options { skipDefaultCheckout() }
-            steps {
-                deleteDir()
-                gitCheckout(basedir: BASE_DIR)
-                stash name: 'source', useDefaultExcludes: false
-            }
-        }
         stage('Build Matrix') {
           matrix {
             agent { label 'ubuntu-20 && immutable' }

--- a/.ci/llvm-apple.groovy
+++ b/.ci/llvm-apple.groovy
@@ -48,7 +48,7 @@ pipeline {
           // changelog '.ci/llvm-apple.groovy'
           // changeset '/go/llvm-apple/**'
           // changeset '.ci/llvm-apple.groovy'
-          expresion {  isGitRegionMatch(patterns: ['^\\.ci/llvm-apple.groovy', '^/go/llvm-apple'], shouldMatchAll: false) }
+          expresion {  return isGitRegionMatch(patterns: ['^\\.ci/llvm-apple.groovy', '^/go/llvm-apple'], shouldMatchAll: false) }
           expression { return isUserTrigger() }
         }
       }

--- a/.ci/llvm-apple.groovy
+++ b/.ci/llvm-apple.groovy
@@ -44,8 +44,8 @@ pipeline {
     stage('Check changes'){
       when {
         anyOf {
-          changelog pattern: '/go/llvm-apple/*', comparator: "GLOB"
-          changelog pattern: '.ci/llvm-apple.groovy', comparator: "EQUALS"
+          changelog pattern: '/go/llvm-apple/*'
+          changelog pattern: '.ci/llvm-apple.groovy'
           expression { return isUserTrigger() }
         }
       }

--- a/.ci/llvm-apple.groovy
+++ b/.ci/llvm-apple.groovy
@@ -44,8 +44,8 @@ pipeline {
     stage('Check changes'){
       when {
         anyOf {
-          changeset pattern: '^/go/llvm-apple', comparator: "REGEXP"
-          changeset pattern: '^.ci/llvm-apple.groovy', comparator: "REGEXP"
+          changelog pattern: '/go/llvm-apple/*', comparator: "GLOB"
+          changelog pattern: '.ci/llvm-apple.groovy', comparator: "EQUALS"
           expression { return isUserTrigger() }
         }
       }

--- a/.ci/llvm-apple.groovy
+++ b/.ci/llvm-apple.groovy
@@ -98,7 +98,7 @@ pipeline {
         }
       }
     }
-    stage('when isGitRegionMatch'){
+    stage('when isGitRegionMatch 2'){
       when {
         expression {
           return  dir(BASE_DIR){isGitRegionMatch(patterns: ['^\\.ci/llvm-apple.groovy', '^/go/llvm-apple'], shouldMatchAll: false)}

--- a/.ci/llvm-apple.groovy
+++ b/.ci/llvm-apple.groovy
@@ -48,7 +48,7 @@ pipeline {
           // changelog '.ci/llvm-apple.groovy'
           // changeset '/go/llvm-apple/**'
           // changeset '.ci/llvm-apple.groovy'
-          expresion {  return isGitRegionMatch(patterns: ['^\\.ci/llvm-apple.groovy', '^/go/llvm-apple'], shouldMatchAll: false) }
+          expression {  return isGitRegionMatch(patterns: ['^\\.ci/llvm-apple.groovy', '^/go/llvm-apple'], shouldMatchAll: false) }
           expression { return isUserTrigger() }
         }
       }

--- a/.ci/llvm-apple.groovy
+++ b/.ci/llvm-apple.groovy
@@ -44,10 +44,11 @@ pipeline {
     stage('Check changes'){
       when {
         anyOf {
-          changelog '/go/llvm-apple/*'
-          changelog '.ci/llvm-apple.groovy'
-          changeset '/go/llvm-apple/**'
-          changeset '.ci/llvm-apple.groovy'
+          // changelog '/go/llvm-apple/*'
+          // changelog '.ci/llvm-apple.groovy'
+          // changeset '/go/llvm-apple/**'
+          // changeset '.ci/llvm-apple.groovy'
+          expresion {  isGitRegionMatch(patterns: ['^\\.ci/llvm-apple.groovy', '^/go/llvm-apple'], shouldMatchAll: false) }
           expression { return isUserTrigger() }
         }
       }

--- a/go/llvm-apple/Makefile
+++ b/go/llvm-apple/Makefile
@@ -17,3 +17,4 @@ build:
 	--build-arg VCS_REF="$(VCS_REF)" \
 	--build-arg VCS_URL="$(VCS_URL)" \
 	--build-arg BUILD_DATE="$(BUILD_DATE)" \
+	.

--- a/go/llvm-apple/Makefile
+++ b/go/llvm-apple/Makefile
@@ -1,5 +1,10 @@
 include ../Makefile.common
 
+SUFFIX         := $(shell basename $(CURDIR))
+
+copy-npcap:
+	@echo "NOOP"
+
 build:
 	@echo ">> Building $(REPOSITORY)/$(NAME):$(SUFFIX)$(TAG_EXTENSION)"
 	@go run $(SELF_DIR)/../template.go -t Dockerfile.tmpl -o Dockerfile

--- a/go/llvm-apple/Makefile
+++ b/go/llvm-apple/Makefile
@@ -1,1 +1,14 @@
 include ../Makefile.common
+
+build:
+	@echo ">> Building $(REPOSITORY)/$(NAME):$(SUFFIX)$(TAG_EXTENSION)"
+	@go run $(SELF_DIR)/../template.go -t Dockerfile.tmpl -o Dockerfile
+	@docker build -t "$(REPOSITORY)/$(NAME):$(SUFFIX)$(TAG_EXTENSION)" \
+	--build-arg REPOSITORY=$(REPOSITORY) \
+	--build-arg VERSION=$(VERSION) \
+	--build-arg DEBIAN_VERSION=$(DEBIAN_VERSION) \
+	--build-arg TAG_EXTENSION=$(TAG_EXTENSION) \
+	--build-arg IMAGE="$(REPOSITORY)/$(NAME):$(SUFFIX)$(TAG_EXTENSION)" \
+	--build-arg VCS_REF="$(VCS_REF)" \
+	--build-arg VCS_URL="$(VCS_URL)" \
+	--build-arg BUILD_DATE="$(BUILD_DATE)" \

--- a/go/llvm-apple/Makefile
+++ b/go/llvm-apple/Makefile
@@ -21,5 +21,5 @@ build:
 	.
 
 atomic-push:
-	@echo ">> Pushing $(REPOSITORY)/$(NAME):$(TAG)"
-	@docker push "$(REPOSITORY)/$(NAME):$(TAG)"
+	@echo ">> Pushing $(TAG)"
+	@echo docker push "$(TAG)"

--- a/go/llvm-apple/Makefile
+++ b/go/llvm-apple/Makefile
@@ -1,20 +1,25 @@
 include ../Makefile.common
 
 SUFFIX         := $(shell basename $(CURDIR))
+TAG 		   := $(REPOSITORY)/$(NAME):$(SUFFIX)$(TAG_EXTENSION)
 
 copy-npcap:
 	@echo "NOOP"
 
 build:
-	@echo ">> Building $(REPOSITORY)/$(NAME):$(SUFFIX)$(TAG_EXTENSION)"
+	@echo ">> Building $(TAG)"
 	@go run $(SELF_DIR)/../template.go -t Dockerfile.tmpl -o Dockerfile
-	@docker build -t "$(REPOSITORY)/$(NAME):$(SUFFIX)$(TAG_EXTENSION)" \
+	@docker build -t "$(TAG)" \
 	--build-arg REPOSITORY=$(REPOSITORY) \
 	--build-arg VERSION=$(VERSION) \
 	--build-arg DEBIAN_VERSION=$(DEBIAN_VERSION) \
 	--build-arg TAG_EXTENSION=$(TAG_EXTENSION) \
-	--build-arg IMAGE="$(REPOSITORY)/$(NAME):$(SUFFIX)$(TAG_EXTENSION)" \
+	--build-arg IMAGE="$(TAG)" \
 	--build-arg VCS_REF="$(VCS_REF)" \
 	--build-arg VCS_URL="$(VCS_URL)" \
 	--build-arg BUILD_DATE="$(BUILD_DATE)" \
 	.
+
+atomic-push:
+	@echo ">> Pushing $(REPOSITORY)/$(NAME):$(TAG)"
+	@docker push "$(REPOSITORY)/$(NAME):$(TAG)"


### PR DESCRIPTION
The Go version is not relevant for the LLVM Docker image, it only depends on the Debian version we are using.