### PR TITLE
jjbb: build go version branches (major.minor)

### DIFF
--- a/.ci/jobs/fpm-mbp.yml
+++ b/.ci/jobs/fpm-mbp.yml
@@ -13,7 +13,7 @@
           discover-pr-forks-trust: permission
           discover-pr-origin: merge-current
           discover-tags: false
-          head-filter-regex: '(main|\d+\.\d+.\d+|PR-.*|v\d+\.\d+\.\d+)'
+          head-filter-regex: '(main|\d+\.\d+.*|PR-.*)'
           disable-pr-notifications: true
           notification-context: 'fpm'
           repo: golang-crossbuild

--- a/.ci/jobs/golang-crossbuild-mbp.yml
+++ b/.ci/jobs/golang-crossbuild-mbp.yml
@@ -13,7 +13,7 @@
           discover-pr-forks-trust: permission
           discover-pr-origin: merge-current
           discover-tags: false
-          head-filter-regex: '(main|\d+\.\d+.\d+|PR-.*|v\d+\.\d+\.\d+)'
+          head-filter-regex: '(main|\d+\.\d+.*|PR-.*)'
           notification-context: 'beats-ci'
           repo: golang-crossbuild
           repo-owner: elastic

--- a/.ci/jobs/llvm-apple-mbp.yml
+++ b/.ci/jobs/llvm-apple-mbp.yml
@@ -13,7 +13,7 @@
           discover-pr-forks-trust: permission
           discover-pr-origin: merge-current
           discover-tags: false
-          head-filter-regex: '(main|\d+\.\d+.\d+|PR-.*|v\d+\.\d+\.\d+)'
+          head-filter-regex: '(main|\d+\.\d+.*|PR-.*)'
           disable-pr-notifications: true
           notification-context: 'llvm-apple'
           repo: golang-crossbuild


### PR DESCRIPTION
Current active branches:
* https://github.com/elastic/golang-crossbuild/tree/main
* https://github.com/elastic/golang-crossbuild/tree/1.16
* https://github.com/elastic/golang-crossbuild/tree/1.17
* https://github.com/elastic/golang-crossbuild/tree/1.17.5.x