### PR TITLE
feat: add binutils-mutiarch

### DIFF
--- a/go/base/Dockerfile.tmpl
+++ b/go/base/Dockerfile.tmpl
@@ -19,6 +19,8 @@ RUN apt-get -o Acquire::Check-Valid-Until=false update -y --no-install-recommend
             flex \
             bison \
 {{if or (eq .DEBIAN_VERSION "10") (eq .DEBIAN_VERSION "11")}}
+            binutils-multiarch \
+            binutils-multiarch-dev \
             python3-venv \
             python3-pip \
             python3 \


### PR DESCRIPTION
Binary utilities that support multi-arch targets
The programs in this package are used to manipulate binary and object files that may have been created on other architectures. This package is primarily for multi-architecture developers and cross-compilers and is not needed by normal users or developers. Note that a cross-assembling version of gas is not included in this package, just the binary utilities.

related to https://github.com/elastic/golang-crossbuild/issues/153