### PR TITLE
[automation] Update go release version 1.18.2

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,7 @@ pipeline {
     DOCKER_REGISTRY_SECRET = 'secret/observability-team/ci/docker-registry/prod'
     REGISTRY = 'docker.elastic.co'
     STAGING_IMAGE = "${env.REGISTRY}/observability-ci"
-    GO_VERSION = '1.18.1'
+    GO_VERSION = '1.18.2'
   }
   options {
     timeout(time: 3, unit: 'HOURS')

--- a/go/Makefile.common
+++ b/go/Makefile.common
@@ -2,7 +2,7 @@ SELF_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 include $(SELF_DIR)/../Makefile.common
 
 NAME           := golang-crossbuild
-VERSION        := 1.18.1
+VERSION        := 1.18.2
 DEBIAN_VERSION ?= 9
 SUFFIX         := -$(shell basename $(CURDIR))
 TAG_EXTENSION  ?=

--- a/go/base-arm/Dockerfile.tmpl
+++ b/go/base-arm/Dockerfile.tmpl
@@ -37,9 +37,9 @@ RUN \
             libsqlite3-0 \
         && rm -rf /var/lib/apt/lists/*
 
-ARG GOLANG_VERSION=1.18.1
+ARG GOLANG_VERSION=1.18.2
 ARG GOLANG_DOWNLOAD_URL=https://golang.org/dl/go$GOLANG_VERSION.linux-arm64.tar.gz
-ARG GOLANG_DOWNLOAD_SHA256=56a91851c97fb4697077abbca38860f735c32b38993ff79b088dac46e4735633
+ARG GOLANG_DOWNLOAD_SHA256=fc4ad28d0501eaa9c9d6190de3888c9d44d8b5fb02183ce4ae93713f67b8a35b
 
 RUN curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz \
 	&& echo "$GOLANG_DOWNLOAD_SHA256  golang.tar.gz" | sha256sum -c - \

--- a/go/base/Dockerfile.tmpl
+++ b/go/base/Dockerfile.tmpl
@@ -29,9 +29,9 @@ RUN apt-get -o Acquire::Check-Valid-Until=false update -y --no-install-recommend
 RUN ln -s /usr/bin/pip3 /usr/bin/pip
 {{- end }}
 
-ARG GOLANG_VERSION=1.18.1
+ARG GOLANG_VERSION=1.18.2
 ARG GOLANG_DOWNLOAD_URL=https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
-ARG GOLANG_DOWNLOAD_SHA256=b3b815f47ababac13810fc6021eb73d65478e0b2db4b09d348eefad9581a2334
+ARG GOLANG_DOWNLOAD_SHA256=e54bec97a1a5d230fc2f9ad0880fcbabb5888f30ed9666eca4a91c5a32e86cbc
 
 RUN curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz \
 	&& echo "$GOLANG_DOWNLOAD_SHA256  golang.tar.gz" | sha256sum -c - \

--- a/go/base/install-go.sh
+++ b/go/base/install-go.sh
@@ -14,7 +14,7 @@ if [ "$(uname -m)" == "x86_64" ]; then
 fi
 
 GOLANG_DOWNLOAD_URL=https://golang.org/dl/go$GOLANG_VERSION.linux-arm64.tar.gz
-GOLANG_DOWNLOAD_SHA256=56a91851c97fb4697077abbca38860f735c32b38993ff79b088dac46e4735633
+GOLANG_DOWNLOAD_SHA256=fc4ad28d0501eaa9c9d6190de3888c9d44d8b5fb02183ce4ae93713f67b8a35b
 
 if [ "$(uname -m)" != "x86_64" ]; then
     curl -fsSL "$GOLANG_DOWNLOAD_URL" -o "${GO_TAR_FILE}"

--- a/go/base/install-go.sh
+++ b/go/base/install-go.sh
@@ -2,9 +2,9 @@
 # This script install the Go version correct for each architecture.
 set -e
 
-GOLANG_VERSION=1.18.1
+GOLANG_VERSION=1.18.2
 GOLANG_DOWNLOAD_URL=https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
-GOLANG_DOWNLOAD_SHA256=b3b815f47ababac13810fc6021eb73d65478e0b2db4b09d348eefad9581a2334
+GOLANG_DOWNLOAD_SHA256=e54bec97a1a5d230fc2f9ad0880fcbabb5888f30ed9666eca4a91c5a32e86cbc
 
 GO_TAR_FILE=/tmp/golang.tar.gz
 


### PR DESCRIPTION
### What 
 Bump go release version with the latest release. 
 ### Further details 
 See [changelog](https://github.com/golang/go/issues?q=milestone%3AGo1.18.2+label%3ACherryPickApproved) for 1.18.2