### PR TITLE
fix auto-bump

### DIFF
--- a/.ci/bump-go-release-version.sh
+++ b/.ci/bump-go-release-version.sh
@@ -21,6 +21,8 @@ else
 fi
 
 MAJOR_MINOR_VERSION=$(echo "$GO_RELEASE_VERSION" | sed -E -e "s#([0-9]+\.[0-9]+).*#\1#g")
+GOLANG_DOWNLOAD_SHA256_ARM=$(curl -s -L https://golang.org/dl/\?mode\=json | jq -r ".[] | select( .version | contains(\"go${GO_RELEASE_VERSION}\")) | .files[] | select (.filename | contains(\"go${GO_RELEASE_VERSION}.linux-arm64.tar.gz\")) | .sha256")
+GOLANG_DOWNLOAD_SHA256_AMD=$(curl -s -L https://golang.org/dl/\?mode\=json | jq -r ".[] | select( .version | contains(\"go${GO_RELEASE_VERSION}\")) | .files[] | select (.filename | contains(\"go${GO_RELEASE_VERSION}.linux-amd64.tar.gz\")) | .sha256")
 
 echo "Update go version ${GO_RELEASE_VERSION}"
 ${SED} -E -e "s#(VERSION[[:space:]]+):= .*#\1:= ${GO_RELEASE_VERSION}#g" "go/Makefile.common"
@@ -31,8 +33,6 @@ git add Jenkinsfile
 find "go" -type f -name Dockerfile.tmpl -print0 |
     while IFS= read -r -d '' line; do
         ${SED} -E -e "s#(ARG GOLANG_VERSION)=[0-9]+\.[0-9]+\.[0-9]+#\1=${GO_RELEASE_VERSION}#g" "$line"
-        GOLANG_DOWNLOAD_SHA256_ARM=$(curl -s -L https://golang.org/dl/\?mode\=json | jq -r ".[] | select( .version | contains(\"go${GO_RELEASE_VERSION}\")) | .files[] | select (.filename | contains(\"go${GO_RELEASE_VERSION}.linux-arm64.tar.gz\")) | .sha256")
-        GOLANG_DOWNLOAD_SHA256_AMD=$(curl -s -L https://golang.org/dl/\?mode\=json | jq -r ".[] | select( .version | contains(\"go${GO_RELEASE_VERSION}\")) | .files[] | select (.filename | contains(\"go${GO_RELEASE_VERSION}.linux-amd64.tar.gz\")) | .sha256")
         if echo "$line" | grep -q 'arm' ; then
             ${SED} -E -e "s#(ARG GOLANG_DOWNLOAD_SHA256)=.+#\1=${GOLANG_DOWNLOAD_SHA256_ARM}#g" "$line"
         else
@@ -40,6 +40,13 @@ find "go" -type f -name Dockerfile.tmpl -print0 |
         fi
         git add "${line}"
     done
+
+if [ -e go/base/install-go.sh ] ; then
+    ${SED} -E -e "s#(GOLANG_VERSION)=[0-9]+\.[0-9]+\.[0-9]+#\1=${GO_RELEASE_VERSION}#g" go/base/install-go.sh
+    ${SED} -E -e "s#(GOLANG_DOWNLOAD_SHA256_AMD)=.+#\1=${GOLANG_DOWNLOAD_SHA256_AMD}#g" go/base/install-go.sh
+    ${SED} -E -e "s#(GOLANG_DOWNLOAD_SHA256_ARM)=.+#\1=${GOLANG_DOWNLOAD_SHA256_ARM}#g" go/base/install-go.sh
+    git add go/base/install-go.sh
+fi
 
 git diff --staged --quiet || git commit -m "[Automation] Update go release version to ${GO_RELEASE_VERSION}"
 git --no-pager log -1

--- a/go/base/install-go.sh
+++ b/go/base/install-go.sh
@@ -18,8 +18,6 @@ fi
 
 GOLANG_DOWNLOAD_URL=https://golang.org/dl/go$GOLANG_VERSION.linux-arm64.tar.gz
 
-GOLANG_DOWNLOAD_SHA256_ARM
-
 if [ "$(uname -m)" != "x86_64" ]; then
     curl -fsSL "$GOLANG_DOWNLOAD_URL" -o "${GO_TAR_FILE}"
     echo "$GOLANG_DOWNLOAD_SHA256_ARM  ${GO_TAR_FILE}" | sha256sum -c -

--- a/go/base/install-go.sh
+++ b/go/base/install-go.sh
@@ -2,23 +2,27 @@
 # This script install the Go version correct for each architecture.
 set -e
 
+## These variables are automatically bumped.
+## If you change their name please change .ci/bump-go-release-version.sh
 GOLANG_VERSION=1.18.1
 GOLANG_DOWNLOAD_URL=https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
-GOLANG_DOWNLOAD_SHA256=b3b815f47ababac13810fc6021eb73d65478e0b2db4b09d348eefad9581a2334
+GOLANG_DOWNLOAD_SHA256_AMD=b3b815f47ababac13810fc6021eb73d65478e0b2db4b09d348eefad9581a2334
+GOLANG_DOWNLOAD_SHA256_ARM=56a91851c97fb4697077abbca38860f735c32b38993ff79b088dac46e4735633
 
 GO_TAR_FILE=/tmp/golang.tar.gz
 
 if [ "$(uname -m)" == "x86_64" ]; then
     curl -fsSL "$GOLANG_DOWNLOAD_URL" -o "${GO_TAR_FILE}"
-    echo "$GOLANG_DOWNLOAD_SHA256  ${GO_TAR_FILE}" | sha256sum -c -
+    echo "$GOLANG_DOWNLOAD_SHA256_AMD  ${GO_TAR_FILE}" | sha256sum -c -
 fi
 
 GOLANG_DOWNLOAD_URL=https://golang.org/dl/go$GOLANG_VERSION.linux-arm64.tar.gz
-GOLANG_DOWNLOAD_SHA256=56a91851c97fb4697077abbca38860f735c32b38993ff79b088dac46e4735633
+
+GOLANG_DOWNLOAD_SHA256_ARM
 
 if [ "$(uname -m)" != "x86_64" ]; then
     curl -fsSL "$GOLANG_DOWNLOAD_URL" -o "${GO_TAR_FILE}"
-    echo "$GOLANG_DOWNLOAD_SHA256  ${GO_TAR_FILE}" | sha256sum -c -
+    echo "$GOLANG_DOWNLOAD_SHA256_ARM  ${GO_TAR_FILE}" | sha256sum -c -
 fi
 
 tar -C /usr/local -xzf "${GO_TAR_FILE}"


### PR DESCRIPTION
### What

Since https://github.com/elastic/golang-crossbuild/blob/main/go/base/install-go.sh has been added then the bump automation should be changed

### Test


Given `1.18.2` then

```diff
diff --git a/Jenkinsfile b/Jenkinsfile
index 4abab22..ccda557 100644
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,7 @@ pipeline {
     DOCKER_REGISTRY_SECRET = 'secret/observability-team/ci/docker-registry/prod'
     DOCKER_REGISTRY = 'docker.elastic.co'
     STAGING_IMAGE = "${env.DOCKER_REGISTRY}/observability-ci"
-    GO_VERSION = '1.18.1'
+    GO_VERSION = '1.18.2'
     BUILDX = "1"
   }
   options {
diff --git a/go/Makefile.common b/go/Makefile.common
index 66499eb..2ce4ad9 100644
--- a/go/Makefile.common
+++ b/go/Makefile.common
@@ -2,7 +2,7 @@ SELF_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 include $(SELF_DIR)/../Makefile.common
 
 NAME           := golang-crossbuild
-VERSION        := 1.18.1
+VERSION        := 1.18.2
 DEBIAN_VERSION ?= 9
 SUFFIX         := -$(shell basename $(CURDIR))
 TAG_EXTENSION  ?=
diff --git a/go/base-arm/Dockerfile.tmpl b/go/base-arm/Dockerfile.tmpl
index a657117..934b702 100644
--- a/go/base-arm/Dockerfile.tmpl
+++ b/go/base-arm/Dockerfile.tmpl
@@ -37,9 +37,9 @@ RUN \
             libsqlite3-0 \
         && rm -rf /var/lib/apt/lists/*
 
-ARG GOLANG_VERSION=1.18.1
+ARG GOLANG_VERSION=1.18.2
 ARG GOLANG_DOWNLOAD_URL=https://golang.org/dl/go$GOLANG_VERSION.linux-arm64.tar.gz
-ARG GOLANG_DOWNLOAD_SHA256=56a91851c97fb4697077abbca38860f735c32b38993ff79b088dac46e4735633
+ARG GOLANG_DOWNLOAD_SHA256=fc4ad28d0501eaa9c9d6190de3888c9d44d8b5fb02183ce4ae93713f67b8a35b
 
 RUN curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz \
 	&& echo "$GOLANG_DOWNLOAD_SHA256  golang.tar.gz" | sha256sum -c - \
diff --git a/go/base/install-go.sh b/go/base/install-go.sh
index 425312c..7f8a7c5 100644
--- a/go/base/install-go.sh
+++ b/go/base/install-go.sh
@@ -4,10 +4,10 @@ set -e
 
 ## These variables are automatically bumped.
 ## If you change their name please change .ci/bump-go-release-version.sh
-GOLANG_VERSION=1.18.1
+GOLANG_VERSION=1.18.2
 GOLANG_DOWNLOAD_URL=https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
-GOLANG_DOWNLOAD_SHA256_AMD=b3b815f47ababac13810fc6021eb73d65478e0b2db4b09d348eefad9581a2334
-GOLANG_DOWNLOAD_SHA256_ARM=56a91851c97fb4697077abbca38860f735c32b38993ff79b088dac46e4735633
+GOLANG_DOWNLOAD_SHA256_AMD=e54bec97a1a5d230fc2f9ad0880fcbabb5888f30ed9666eca4a91c5a32e86cbc
+GOLANG_DOWNLOAD_SHA256_ARM=fc4ad28d0501eaa9c9d6190de3888c9d44d8b5fb02183ce4ae93713f67b8a35b
 
 GO_TAR_FILE=/tmp/golang.tar.gz
 
```