### PR TITLE
[automation] Update go release version 1.18.5

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,7 @@ pipeline {
     DOCKER_REGISTRY_SECRET = 'secret/observability-team/ci/docker-registry/prod'
     DOCKER_REGISTRY = 'docker.elastic.co'
     STAGING_IMAGE = "${env.DOCKER_REGISTRY}/observability-ci"
-    GO_VERSION = '1.18.4'
+    GO_VERSION = '1.18.5'
     BUILDX = "1"
   }
   options {

--- a/go/Makefile.common
+++ b/go/Makefile.common
@@ -2,7 +2,7 @@ SELF_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 include $(SELF_DIR)/../Makefile.common
 
 NAME           := golang-crossbuild
-VERSION        := 1.18.4
+VERSION        := 1.18.5
 DEBIAN_VERSION ?= 9
 SUFFIX         := -$(shell basename $(CURDIR))
 TAG_EXTENSION  ?=

--- a/go/base-arm/Dockerfile.tmpl
+++ b/go/base-arm/Dockerfile.tmpl
@@ -37,9 +37,9 @@ RUN \
             libsqlite3-0 \
         && rm -rf /var/lib/apt/lists/*
 
-ARG GOLANG_VERSION=1.18.4
+ARG GOLANG_VERSION=1.18.5
 ARG GOLANG_DOWNLOAD_URL=https://golang.org/dl/go$GOLANG_VERSION.linux-arm64.tar.gz
-ARG GOLANG_DOWNLOAD_SHA256=35014d92b50d97da41dade965df7ebeb9a715da600206aa59ce1b2d05527421f
+ARG GOLANG_DOWNLOAD_SHA256=006f6622718212363fa1ff004a6ab4d87bbbe772ec5631bab7cac10be346e4f1
 
 RUN curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz \
 	&& echo "$GOLANG_DOWNLOAD_SHA256  golang.tar.gz" | sha256sum -c - \

--- a/go/base/install-go.sh
+++ b/go/base/install-go.sh
@@ -4,10 +4,10 @@ set -e
 
 ## These variables are automatically bumped.
 ## If you change their name please change .ci/bump-go-release-version.sh
-GOLANG_VERSION=1.18.4
+GOLANG_VERSION=1.18.5
 GOLANG_DOWNLOAD_URL=https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
-GOLANG_DOWNLOAD_SHA256_AMD=c9b099b68d93f5c5c8a8844a89f8db07eaa58270e3a1e01804f17f4cf8df02f5
-GOLANG_DOWNLOAD_SHA256_ARM=35014d92b50d97da41dade965df7ebeb9a715da600206aa59ce1b2d05527421f
+GOLANG_DOWNLOAD_SHA256_AMD=9e5de37f9c49942c601b191ac5fba404b868bfc21d446d6960acc12283d6e5f2
+GOLANG_DOWNLOAD_SHA256_ARM=006f6622718212363fa1ff004a6ab4d87bbbe772ec5631bab7cac10be346e4f1
 
 GO_TAR_FILE=/tmp/golang.tar.gz
 


### PR DESCRIPTION
### What 

Bump go release version with the latest release. 

### Further details 

See [changelog](https://github.com/golang/go/issues?q=milestone%3AGo1.18.5+label%3ACherryPickApproved) for 1.18.5

 


_Automatically generated from https://apm-ci.elastic.co/job/apm-shared/job/bump-go-release-version-pipeline/_