### PR TITLE
[automation] Update go release version 1.17.13

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
     DOCKER_REGISTRY_SECRET = 'secret/observability-team/ci/docker-registry/prod'
     REGISTRY = 'docker.elastic.co'
     STAGING_IMAGE = "${env.REGISTRY}/observability-ci"
-    GO_VERSION = '1.17.12'
+    GO_VERSION = '1.17.13'
     BUILDX = "1"
   }
   options {

--- a/go/Makefile.common
+++ b/go/Makefile.common
@@ -2,7 +2,7 @@ SELF_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 include $(SELF_DIR)/../Makefile.common
 
 NAME           := golang-crossbuild
-VERSION        := 1.17.12
+VERSION        := 1.17.13
 DEBIAN_VERSION ?= 9
 SUFFIX         := -$(shell basename $(CURDIR))
 TAG_EXTENSION  ?=

--- a/go/base-arm/Dockerfile.tmpl
+++ b/go/base-arm/Dockerfile.tmpl
@@ -37,9 +37,9 @@ RUN \
             libsqlite3-0 \
         && rm -rf /var/lib/apt/lists/*
 
-ARG GOLANG_VERSION=1.17.12
+ARG GOLANG_VERSION=1.17.13
 ARG GOLANG_DOWNLOAD_URL=https://golang.org/dl/go$GOLANG_VERSION.linux-arm64.tar.gz
-ARG GOLANG_DOWNLOAD_SHA256=74a4832d0f150a2d768a6781553494ba84152e854ebef743c4092cd9d1f66a9f
+ARG GOLANG_DOWNLOAD_SHA256=914daad3f011cc2014dea799bb7490442677e4ad6de0b2ac3ded6cee7e3f493d
 
 RUN curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz \
 	&& echo "$GOLANG_DOWNLOAD_SHA256  golang.tar.gz" | sha256sum -c - \

--- a/go/base/install-go.sh
+++ b/go/base/install-go.sh
@@ -4,10 +4,10 @@ set -e
 
 ## These variables are automatically bumped.
 ## If you change their name please change .ci/bump-go-release-version.sh
-GOLANG_VERSION=1.17.12
+GOLANG_VERSION=1.17.13
 GOLANG_DOWNLOAD_URL=https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
-GOLANG_DOWNLOAD_SHA256_AMD=6e5203fbdcade4aa4331e441fd2e1db8444681a6a6c72886a37ddd11caa415d4
-GOLANG_DOWNLOAD_SHA256_ARM=74a4832d0f150a2d768a6781553494ba84152e854ebef743c4092cd9d1f66a9f
+GOLANG_DOWNLOAD_SHA256_AMD=4cdd2bc664724dc7db94ad51b503512c5ae7220951cac568120f64f8e94399fc
+GOLANG_DOWNLOAD_SHA256_ARM=914daad3f011cc2014dea799bb7490442677e4ad6de0b2ac3ded6cee7e3f493d
 
 GO_TAR_FILE=/tmp/golang.tar.gz
 


### PR DESCRIPTION
### What 

Bump go release version with the latest release. 

### Further details 

See [changelog](https://github.com/golang/go/issues?q=milestone%3AGo1.17.13+label%3ACherryPickApproved) for 1.17.13

 


_Automatically generated from https://apm-ci.elastic.co/job/apm-shared/job/bump-go-release-version-pipeline/_