### PR TITLE
fix: remove support for Debian 10 on armel, mips, mips32, ppc and s390x

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,7 @@ needed when the application uses [cgo](https://golang.org/cmd/cgo/).
 
 The base image used is Debian 9 (stretch) unless otherwise specified.
 
-`armel`, `ppc`, `s390x` are only based on `Debian 11`.
-
-`mips`, `mips32` is not generated.
+`armel`, `mips`, `mips32`, `ppc`, `s390x` are only based on `Debian 11`.
 
 ## Docker Repo
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ needed when the application uses [cgo](https://golang.org/cmd/cgo/).
 
 The base image used is Debian 9 (stretch) unless otherwise specified.
 
-`mips`, `mips32`, `ppc`, `s390x` and `darwin-arm64` are only based on `Debian 10`.
+`armel`, `ppc`, `s390x` are only based on `Debian 11`.
+
+`mips`, `mips32` is not generated.
 
 ## Docker Repo
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ needed when the application uses [cgo](https://golang.org/cmd/cgo/).
 
 The base image used is Debian 9 (stretch) unless otherwise specified.
 
-`armel`, `mips`, `mips32`, `ppc`, `s390x` are only based on `Debian 11`.
+The `armel`, `mips`, `ppc` and `s390x` platforms are only supported from `Debian 11` onwards. The last known version for `Debian 10` was based on Golang version `1.18.4`/`1.17.12`.
+
+`mips32` is not available in `Debian 11`.
 
 ## Docker Repo
 

--- a/go/Makefile.debian10
+++ b/go/Makefile.debian10
@@ -1,4 +1,4 @@
-IMAGES         := base main darwin arm armhf armel mips mips32 ppc s390x darwin-arm64 npcap
+IMAGES         ?= base main darwin arm armhf darwin-arm64 npcap
 DEBIAN_VERSION := 10
 TAG_EXTENSION  := -debian10
 

--- a/go/Makefile.debian11
+++ b/go/Makefile.debian11
@@ -1,4 +1,4 @@
-IMAGES         ?= base main darwin arm armhf armel mips mips32 ppc s390x darwin-arm64 npcap
+IMAGES         := base main darwin arm armhf armel mips ppc s390x darwin-arm64 npcap
 DEBIAN_VERSION := 11
 TAG_EXTENSION  := -debian11
 

--- a/go/Makefile.debian11
+++ b/go/Makefile.debian11
@@ -1,4 +1,4 @@
-IMAGES         := base main darwin arm armhf armel ppc s390x darwin-arm64 npcap
+IMAGES         ?= base main darwin arm armhf armel mips mips32 ppc s390x darwin-arm64 npcap
 DEBIAN_VERSION := 11
 TAG_EXTENSION  := -debian11
 


### PR DESCRIPTION
### What

Remove support for `Debian 10` on `armel`, `mips`, `mips32`, `ppc` and `s390x`. Recent changes on the `librpm-dev` package in `Debian 10` have broken the way we install this library for cross compile, due to we have support on `Debian 11` that works fine for those architectures (but `mips32`) we remove support for them on `Debian 10`.

### Further details 

Some packages for `mips32` are not available in `Debian 11` therefore 

<img width="673" alt="image" src="https://user-images.githubusercontent.com/2871786/185395010-ae5b2a1a-9935-478d-bd3f-41efcc83dafd.png">

https://packages.debian.org/bullseye/libc6-dev

vs

`Debian 10`

<img width="615" alt="image" src="https://user-images.githubusercontent.com/2871786/185394962-4ea62e30-5669-446b-8ddd-5e76b955212a.png">

https://packages.debian.org/buster/libc6-dev

### Issues

Similar to https://github.com/elastic/golang-crossbuild/pull/175
Closes https://github.com/elastic/golang-crossbuild/issues/224