### PR TITLE
fix: support major.minor in addition to major.minor.patch

### DIFF
--- a/.ci/bump-go-release-version.sh
+++ b/.ci/bump-go-release-version.sh
@@ -32,7 +32,7 @@ git add Jenkinsfile
 
 find "go" -type f -name Dockerfile.tmpl -print0 |
     while IFS= read -r -d '' line; do
-        ${SED} -E -e "s#(ARG GOLANG_VERSION)=[0-9]+\.[0-9]+\.[0-9]+#\1=${GO_RELEASE_VERSION}#g" "$line"
+        ${SED} -E -e "s#(ARG GOLANG_VERSION)=[0-9]+\.[0-9]+(\.[0-9]+)?#\1=${GO_RELEASE_VERSION}#g" "$line"
         if echo "$line" | grep -q 'arm' ; then
             ${SED} -E -e "s#(ARG GOLANG_DOWNLOAD_SHA256)=.+#\1=${GOLANG_DOWNLOAD_SHA256_ARM}#g" "$line"
         else
@@ -42,7 +42,7 @@ find "go" -type f -name Dockerfile.tmpl -print0 |
     done
 
 if [ -e go/base/install-go.sh ] ; then
-    ${SED} -E -e "s#(GOLANG_VERSION)=[0-9]+\.[0-9]+\.[0-9]+#\1=${GO_RELEASE_VERSION}#g" go/base/install-go.sh
+    ${SED} -E -e "s#(GOLANG_VERSION)=[0-9]+\.[0-9]+(\.[0-9]+)?#\1=${GO_RELEASE_VERSION}#g" go/base/install-go.sh
     ${SED} -E -e "s#(GOLANG_DOWNLOAD_SHA256_AMD)=.+#\1=${GOLANG_DOWNLOAD_SHA256_AMD}#g" go/base/install-go.sh
     ${SED} -E -e "s#(GOLANG_DOWNLOAD_SHA256_ARM)=.+#\1=${GOLANG_DOWNLOAD_SHA256_ARM}#g" go/base/install-go.sh
     git add go/base/install-go.sh


### PR DESCRIPTION
## What

Support major.minor in addition to major.minor.patch

## Why

When bumping from 1.18.x to 1.19, the very first version for 1.19 does not have any patch version. Hence the automation for bumping 1.19.1 wont' work since it looks for `major.minor.patch` in the replacement


## Test

`.ci/bump-go-release-version.sh 1.19.1`

produced

```diff
diff --git a/Jenkinsfile b/Jenkinsfile
index 0795d17..111508e 100644
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,7 @@ pipeline {
     DOCKER_REGISTRY_SECRET = 'secret/observability-team/ci/docker-registry/prod'
     DOCKER_REGISTRY = 'docker.elastic.co'
     STAGING_IMAGE = "${env.DOCKER_REGISTRY}/observability-ci"
-    GO_VERSION = '1.19'
+    GO_VERSION = '1.19.1'
     BUILDX = "1"
   }
   options {
diff --git a/go/Makefile.common b/go/Makefile.common
index 222f25b..137dfe8 100644
--- a/go/Makefile.common
+++ b/go/Makefile.common
@@ -2,7 +2,7 @@ SELF_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 include $(SELF_DIR)/../Makefile.common
 
 NAME           := golang-crossbuild
-VERSION        := 1.19
+VERSION        := 1.19.1
 DEBIAN_VERSION ?= 9
 SUFFIX         := -$(shell basename $(CURDIR))
 TAG_EXTENSION  ?=
diff --git a/go/base-arm/Dockerfile.tmpl b/go/base-arm/Dockerfile.tmpl
index bf379c5..14073d1 100644
--- a/go/base-arm/Dockerfile.tmpl
+++ b/go/base-arm/Dockerfile.tmpl
@@ -37,9 +37,9 @@ RUN \
             libsqlite3-0 \
         && rm -rf /var/lib/apt/lists/*
 
-ARG GOLANG_VERSION=1.19
+ARG GOLANG_VERSION=1.19.1
 ARG GOLANG_DOWNLOAD_URL=https://golang.org/dl/go$GOLANG_VERSION.linux-arm64.tar.gz
-ARG GOLANG_DOWNLOAD_SHA256=efa97fac9574fc6ef6c9ff3e3758fb85f1439b046573bf434cccb5e012bd00c8
+ARG GOLANG_DOWNLOAD_SHA256=49960821948b9c6b14041430890eccee58c76b52e2dbaafce971c3c38d43df9f
 
 RUN curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz \
 	&& echo "$GOLANG_DOWNLOAD_SHA256  golang.tar.gz" | sha256sum -c - \
diff --git a/go/base/install-go.sh b/go/base/install-go.sh
index a7f292f..c2b907f 100644
--- a/go/base/install-go.sh
+++ b/go/base/install-go.sh
@@ -4,10 +4,10 @@ set -e
 
 ## These variables are automatically bumped.
 ## If you change their name please change .ci/bump-go-release-version.sh
-GOLANG_VERSION=1.19
+GOLANG_VERSION=1.19.1
 GOLANG_DOWNLOAD_URL=https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
-GOLANG_DOWNLOAD_SHA256_AMD=464b6b66591f6cf055bc5df90a9750bf5fbc9d038722bb84a9d56a2bea974be6
-GOLANG_DOWNLOAD_SHA256_ARM=efa97fac9574fc6ef6c9ff3e3758fb85f1439b046573bf434cccb5e012bd00c8
+GOLANG_DOWNLOAD_SHA256_AMD=acc512fbab4f716a8f97a8b3fbaa9ddd39606a28be6c2515ef7c6c6311acffde
+GOLANG_DOWNLOAD_SHA256_ARM=49960821948b9c6b14041430890eccee58c76b52e2dbaafce971c3c38d43df9f
 
 GO_TAR_FILE=/tmp/golang.tar.gz

```


while `.ci/bump-go-release-version.sh 1.19` afterwards produced

```diff
diff --git a/Jenkinsfile b/Jenkinsfile
index 111508e..0795d17 100644
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,7 @@ pipeline {
     DOCKER_REGISTRY_SECRET = 'secret/observability-team/ci/docker-registry/prod'
     DOCKER_REGISTRY = 'docker.elastic.co'
     STAGING_IMAGE = "${env.DOCKER_REGISTRY}/observability-ci"
-    GO_VERSION = '1.19.1'
+    GO_VERSION = '1.19'
     BUILDX = "1"
   }
   options {
diff --git a/go/Makefile.common b/go/Makefile.common
index 137dfe8..222f25b 100644
--- a/go/Makefile.common
+++ b/go/Makefile.common
@@ -2,7 +2,7 @@ SELF_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 include $(SELF_DIR)/../Makefile.common
 
 NAME           := golang-crossbuild
-VERSION        := 1.19.1
+VERSION        := 1.19
 DEBIAN_VERSION ?= 9
 SUFFIX         := -$(shell basename $(CURDIR))
 TAG_EXTENSION  ?=
diff --git a/go/base-arm/Dockerfile.tmpl b/go/base-arm/Dockerfile.tmpl
index 14073d1..2bc049d 100644
--- a/go/base-arm/Dockerfile.tmpl
+++ b/go/base-arm/Dockerfile.tmpl
@@ -37,9 +37,9 @@ RUN \
             libsqlite3-0 \
         && rm -rf /var/lib/apt/lists/*
 
-ARG GOLANG_VERSION=1.19.1
+ARG GOLANG_VERSION=1.19
 ARG GOLANG_DOWNLOAD_URL=https://golang.org/dl/go$GOLANG_VERSION.linux-arm64.tar.gz
-ARG GOLANG_DOWNLOAD_SHA256=49960821948b9c6b14041430890eccee58c76b52e2dbaafce971c3c38d43df9f
+ARG GOLANG_DOWNLOAD_SHA256=
 
 RUN curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz \
 	&& echo "$GOLANG_DOWNLOAD_SHA256  golang.tar.gz" | sha256sum -c - \
diff --git a/go/base/install-go.sh b/go/base/install-go.sh
index c2b907f..1716645 100644
--- a/go/base/install-go.sh
+++ b/go/base/install-go.sh
@@ -4,10 +4,10 @@ set -e
 
 ## These variables are automatically bumped.
 ## If you change their name please change .ci/bump-go-release-version.sh
-GOLANG_VERSION=1.19.1
+GOLANG_VERSION=1.19
 GOLANG_DOWNLOAD_URL=https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
-GOLANG_DOWNLOAD_SHA256_AMD=acc512fbab4f716a8f97a8b3fbaa9ddd39606a28be6c2515ef7c6c6311acffde
-GOLANG_DOWNLOAD_SHA256_ARM=49960821948b9c6b14041430890eccee58c76b52e2dbaafce971c3c38d43df9f
+GOLANG_DOWNLOAD_SHA256_AMD=
+GOLANG_DOWNLOAD_SHA256_ARM=
 
 GO_TAR_FILE=/tmp/golang.tar.gz
 
```

For some reason, rolling back to `1.19` while `1.19.1` won't work since the sha256 in https://golang.org/dl/?mode=json is gone.

<img width="534" alt="image" src="https://user-images.githubusercontent.com/2871786/189685316-6b7a49f4-d42b-4fae-b3af-57e847c2de58.png">
