### PR TITLE
[automation] Update go release version 1.19.2

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,7 @@ pipeline {
     DOCKER_REGISTRY_SECRET = 'secret/observability-team/ci/docker-registry/prod'
     DOCKER_REGISTRY = 'docker.elastic.co'
     STAGING_IMAGE = "${env.DOCKER_REGISTRY}/observability-ci"
-    GO_VERSION = '1.19.1'
+    GO_VERSION = '1.19.2'
     BUILDX = "1"
   }
   options {

--- a/go/Makefile.common
+++ b/go/Makefile.common
@@ -2,7 +2,7 @@ SELF_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 include $(SELF_DIR)/../Makefile.common
 
 NAME           := golang-crossbuild
-VERSION        := 1.19.1
+VERSION        := 1.19.2
 DEBIAN_VERSION ?= 9
 SUFFIX         := -$(shell basename $(CURDIR))
 TAG_EXTENSION  ?=

--- a/go/base-arm/Dockerfile.tmpl
+++ b/go/base-arm/Dockerfile.tmpl
@@ -37,9 +37,9 @@ RUN \
             libsqlite3-0 \
         && rm -rf /var/lib/apt/lists/*
 
-ARG GOLANG_VERSION=1.19.1
+ARG GOLANG_VERSION=1.19.2
 ARG GOLANG_DOWNLOAD_URL=https://golang.org/dl/go$GOLANG_VERSION.linux-arm64.tar.gz
-ARG GOLANG_DOWNLOAD_SHA256=49960821948b9c6b14041430890eccee58c76b52e2dbaafce971c3c38d43df9f
+ARG GOLANG_DOWNLOAD_SHA256=b62a8d9654436c67c14a0c91e931d50440541f09eb991a987536cb982903126d
 
 RUN curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz \
 	&& echo "$GOLANG_DOWNLOAD_SHA256  golang.tar.gz" | sha256sum -c - \

--- a/go/base/install-go.sh
+++ b/go/base/install-go.sh
@@ -4,10 +4,10 @@ set -e
 
 ## These variables are automatically bumped.
 ## If you change their name please change .ci/bump-go-release-version.sh
-GOLANG_VERSION=1.19.1
+GOLANG_VERSION=1.19.2
 GOLANG_DOWNLOAD_URL=https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
-GOLANG_DOWNLOAD_SHA256_AMD=acc512fbab4f716a8f97a8b3fbaa9ddd39606a28be6c2515ef7c6c6311acffde
-GOLANG_DOWNLOAD_SHA256_ARM=49960821948b9c6b14041430890eccee58c76b52e2dbaafce971c3c38d43df9f
+GOLANG_DOWNLOAD_SHA256_AMD=5e8c5a74fe6470dd7e055a461acda8bb4050ead8c2df70f227e3ff7d8eb7eeb6
+GOLANG_DOWNLOAD_SHA256_ARM=b62a8d9654436c67c14a0c91e931d50440541f09eb991a987536cb982903126d
 
 GO_TAR_FILE=/tmp/golang.tar.gz
 


### PR DESCRIPTION
### What 

Bump go release version with the latest release. 

### Further details 

See [changelog](https://github.com/golang/go/issues?q=milestone%3AGo1.19.2+label%3ACherryPickApproved) for 1.19.2

 


_Automatically generated from https://apm-ci.elastic.co/job/apm-shared/job/bump-go-release-version-pipeline/_