### PR TITLE
[automation] Update go release version 1.18.8

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,7 @@ pipeline {
     DOCKER_REGISTRY_SECRET = 'secret/observability-team/ci/docker-registry/prod'
     DOCKER_REGISTRY = 'docker.elastic.co'
     STAGING_IMAGE = "${env.DOCKER_REGISTRY}/observability-ci"
-    GO_VERSION = '1.18.7'
+    GO_VERSION = '1.18.8'
     BUILDX = "1"
   }
   options {

--- a/go/Makefile.common
+++ b/go/Makefile.common
@@ -2,7 +2,7 @@ SELF_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 include $(SELF_DIR)/../Makefile.common
 
 NAME           := golang-crossbuild
-VERSION        := 1.18.7
+VERSION        := 1.18.8
 DEBIAN_VERSION ?= 9
 SUFFIX         := -$(shell basename $(CURDIR))
 TAG_EXTENSION  ?=

--- a/go/base-arm/Dockerfile.tmpl
+++ b/go/base-arm/Dockerfile.tmpl
@@ -37,9 +37,9 @@ RUN \
             libsqlite3-0 \
         && rm -rf /var/lib/apt/lists/*
 
-ARG GOLANG_VERSION=1.18.7
+ARG GOLANG_VERSION=1.18.8
 ARG GOLANG_DOWNLOAD_URL=https://golang.org/dl/go$GOLANG_VERSION.linux-arm64.tar.gz
-ARG GOLANG_DOWNLOAD_SHA256=dceea023a9f87dc7c3bf638874e34ff1b42b76e3f1e489510a0c5ffde0cad438
+ARG GOLANG_DOWNLOAD_SHA256=df71bc84d84f7f62dad06aca5e1b8234045dce94a94dcefe71af0cb8f6e93a87
 
 RUN curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz \
 	&& echo "$GOLANG_DOWNLOAD_SHA256  golang.tar.gz" | sha256sum -c - \

--- a/go/base/install-go.sh
+++ b/go/base/install-go.sh
@@ -4,10 +4,10 @@ set -e
 
 ## These variables are automatically bumped.
 ## If you change their name please change .ci/bump-go-release-version.sh
-GOLANG_VERSION=1.18.7
+GOLANG_VERSION=1.18.8
 GOLANG_DOWNLOAD_URL=https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
-GOLANG_DOWNLOAD_SHA256_AMD=6c967efc22152ce3124fc35cdf50fc686870120c5fd2107234d05d450a6105d8
-GOLANG_DOWNLOAD_SHA256_ARM=dceea023a9f87dc7c3bf638874e34ff1b42b76e3f1e489510a0c5ffde0cad438
+GOLANG_DOWNLOAD_SHA256_AMD=4d854c7bad52d53470cf32f1b287a5c0c441dc6b98306dea27358e099698142a
+GOLANG_DOWNLOAD_SHA256_ARM=df71bc84d84f7f62dad06aca5e1b8234045dce94a94dcefe71af0cb8f6e93a87
 
 GO_TAR_FILE=/tmp/golang.tar.gz
 


### PR DESCRIPTION
### What 

Bump go release version with the latest release. 

### Further details 

See [changelog](https://github.com/golang/go/issues?q=milestone%3AGo1.18.8+label%3ACherryPickApproved) for 1.18.8

 


_Automatically generated from https://apm-ci.elastic.co/job/apm-shared/job/bump-go-release-version-pipeline/_