### PR TITLE
fix libc6-dev : Depends: libc6 (= 2.31-13+deb11u4) but 2.31-13+deb11u5

### DIFF
--- a/go/base/Dockerfile.tmpl
+++ b/go/base/Dockerfile.tmpl
@@ -25,6 +25,9 @@ RUN apt-get -o Acquire::Check-Valid-Until=false update -y --no-install-recommend
             python3-pip \
             python3 \
 {{- end }}
+{{- if (eq .DEBIAN_VERSION "11")}}
+            libc6=2.31-13+deb11u4 --allow-downgrades \
+{{- end }}
         && rm -rf /var/lib/apt/lists/*
 
 {{- if eq .DEBIAN_VERSION "10"}}

--- a/go/base/Dockerfile.tmpl
+++ b/go/base/Dockerfile.tmpl
@@ -26,6 +26,7 @@ RUN apt-get -o Acquire::Check-Valid-Until=false update -y --no-install-recommend
             python3 \
 {{- end }}
 {{- if (eq .DEBIAN_VERSION "11")}}
+# FIXME remove when the libc6-dev is updated to the new libc6
             libc6=2.31-13+deb11u4 --allow-downgrades \
 {{- end }}
         && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
### What

Debian 11 fails when installing the dependency libc6 since it requires a downgraded version instead. 

### Errors

<img width="1472" alt="image" src="https://user-images.githubusercontent.com/2871786/200325827-21e00ac9-4369-470e-b8ab-0a8e0cae0851.png">


Closes https://github.com/elastic/golang-crossbuild/issues/245