### PR TITLE
Revert "fix libc6-dev : Depends: libc6 (= 2.31-13+deb11u4) but 2.31-13+deb11u5"

### DIFF
--- a/go/base/Dockerfile.tmpl
+++ b/go/base/Dockerfile.tmpl
@@ -25,10 +25,6 @@ RUN apt-get -o Acquire::Check-Valid-Until=false update -y --no-install-recommend
             python3-pip \
             python3 \
 {{- end }}
-{{- if (eq .DEBIAN_VERSION "11")}}
-# FIXME remove when the libc6-dev is updated to the new libc6
-            libc6=2.31-13+deb11u4 --allow-downgrades \
-{{- end }}
         && rm -rf /var/lib/apt/lists/*
 
 {{- if eq .DEBIAN_VERSION "10"}}


### PR DESCRIPTION
Reverts elastic/golang-crossbuild#246

Fixes https://github.com/elastic/golang-crossbuild/issues/251

libc6-dev depends on libc6 with the same version


See https://packages.debian.org/bullseye/libc6-dev


<img width="1147" alt="image" src="https://user-images.githubusercontent.com/2871786/211565455-585d3315-1327-4c66-8116-b10a5ad515e8.png">

