### PR TITLE
Git 2.35.2, released this April, fix a vulnerability CVE-2022-24765

### DIFF
--- a/go/base-arm/rootfs/entrypoint.go
+++ b/go/base-arm/rootfs/entrypoint.go
@@ -61,6 +61,10 @@ func doBuild(_ *cobra.Command, _ []string) error {
 			return fmt.Errorf("failed constructing the build environment for %v: %v", p, err)
 		}
 
+		if err = configureGitCommand(); err != nil {
+			return fmt.Errorf("failed configuring the git context for %v: %v", p, err)
+		}
+
 		if err = execBuildCommand(env); err != nil {
 			return fmt.Errorf("failed building for %v: %v", p, err)
 		}
@@ -169,6 +173,21 @@ func execBuildCommand(env map[string]string) error {
 	var b strings.Builder
 	sort.Strings(logEnv)
 	fmt.Fprintf(&b, ">> Building using: cmd='%v', env=[%v]", buildCommand, strings.Join(logEnv, ", "))
+
+	log.Println(b.String())
+	return cmd.Run()
+}
+
+// See https://github.com/elastic/golang-crossbuild/issues/232
+func configureGitCommand() error {
+	cmd := exec.Command("sh", "-c", "git", "config", "--global", "--add", "safe.directory", "*")
+	cmd.Env = os.Environ()
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
+
+	var b strings.Builder
+	fmt.Fprintf(&b, ">>> Configure Git permissions")
 
 	log.Println(b.String())
 	return cmd.Run()

--- a/go/base/rootfs/entrypoint.go
+++ b/go/base/rootfs/entrypoint.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package main
@@ -61,8 +62,8 @@ func doBuild(_ *cobra.Command, _ []string) error {
 			return fmt.Errorf("failed constructing the build environment for %v: %v", p, err)
 		}
 
-		if err = configureGitCommand(); err != nil {
-			return fmt.Errorf("failed configuring the git context for %v: %v", p, err)
+		if output, err := configureGitCommand(); err != nil {
+			return fmt.Errorf("failed configuring the git context for %v: %v (%v)", p, err, string(output))
 		}
 
 		if err = execBuildCommand(env); err != nil {
@@ -179,7 +180,7 @@ func execBuildCommand(env map[string]string) error {
 }
 
 // See https://github.com/elastic/golang-crossbuild/issues/232
-func configureGitCommand() error {
+func configureGitCommand() ([]byte, error) {
 	cmd := exec.Command("sh", "-c", "git", "config", "--global", "--add", "safe.directory", "*")
 	cmd.Env = os.Environ()
 	cmd.Stdout = os.Stdout
@@ -190,5 +191,5 @@ func configureGitCommand() error {
 	fmt.Fprintf(&b, ">>> Configure Git permissions")
 
 	log.Println(b.String())
-	return cmd.Run()
+	return cmd.CombinedOutput()
 }

--- a/go/base/rootfs/entrypoint.go
+++ b/go/base/rootfs/entrypoint.go
@@ -61,6 +61,10 @@ func doBuild(_ *cobra.Command, _ []string) error {
 			return fmt.Errorf("failed constructing the build environment for %v: %v", p, err)
 		}
 
+		if err = configureGitCommand(); err != nil {
+			return fmt.Errorf("failed configuring the git context for %v: %v", p, err)
+		}
+
 		if err = execBuildCommand(env); err != nil {
 			return fmt.Errorf("failed building for %v: %v", p, err)
 		}
@@ -169,6 +173,21 @@ func execBuildCommand(env map[string]string) error {
 	var b strings.Builder
 	sort.Strings(logEnv)
 	fmt.Fprintf(&b, ">> Building using: cmd='%v', env=[%v]", buildCommand, strings.Join(logEnv, ", "))
+
+	log.Println(b.String())
+	return cmd.Run()
+}
+
+// See https://github.com/elastic/golang-crossbuild/issues/232
+func configureGitCommand() error {
+	cmd := exec.Command("sh", "-c", "git", "config", "--global", "--add", "safe.directory", "*")
+	cmd.Env = os.Environ()
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
+
+	var b strings.Builder
+	fmt.Fprintf(&b, ">>> Configure Git permissions")
 
 	log.Println(b.String())
 	return cmd.Run()


### PR DESCRIPTION
### Motivation

Git 2.35.2, released this April, fix a vulnerability CVE-2022-24765

So let's use the approach suggested in https://github.com/elastic/golang-crossbuild/issues/232 but using the `*` rather than the current workspace.

