### PR TITLE
feat: support for golang 1.20

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -115,3 +115,16 @@ pull_request_rules:
         labels:
           - "backport"
         title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"
+  - name: backport patches to 1.19 branch
+    conditions:
+      - merged
+      - label=backport-v1.19
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        branches:
+          - "1.19"
+        labels:
+          - "backport"
+        title: "[{{ destination_branch }}](backport #{{ number }}) {{ title }}"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,7 @@ pipeline {
     DOCKER_REGISTRY_SECRET = 'secret/observability-team/ci/docker-registry/prod'
     DOCKER_REGISTRY = 'docker.elastic.co'
     STAGING_IMAGE = "${env.DOCKER_REGISTRY}/observability-ci"
-    GO_VERSION = '1.19.5'
+    GO_VERSION = '1.20rc2'
     BUILDX = "1"
   }
   options {

--- a/go/Makefile.common
+++ b/go/Makefile.common
@@ -2,7 +2,7 @@ SELF_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 include $(SELF_DIR)/../Makefile.common
 
 NAME           := golang-crossbuild
-VERSION        := 1.19.5
+VERSION        := 1.20rc2
 DEBIAN_VERSION ?= 9
 SUFFIX         := -$(shell basename $(CURDIR))
 TAG_EXTENSION  ?=

--- a/go/base-arm/Dockerfile.tmpl
+++ b/go/base-arm/Dockerfile.tmpl
@@ -37,9 +37,9 @@ RUN \
             libsqlite3-0 \
         && rm -rf /var/lib/apt/lists/*
 
-ARG GOLANG_VERSION=1.19.5
-ARG GOLANG_DOWNLOAD_URL=https://golang.org/dl/go$GOLANG_VERSION.linux-arm64.tar.gz
-ARG GOLANG_DOWNLOAD_SHA256=fc0aa29c933cec8d76f5435d859aaf42249aa08c74eb2d154689ae44c08d23b3
+ARG GOLANG_VERSION=1.20rc2
+ARG GOLANG_DOWNLOAD_URL=https://go.dev/dl/go$GOLANG_VERSION.linux-arm64.tar.gz
+ARG GOLANG_DOWNLOAD_SHA256=d14c1eeb9f48e8def6f886f4cdec57c0a90ba47bdee1b79a00543aa30386e3a6
 
 RUN curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz \
 	&& echo "$GOLANG_DOWNLOAD_SHA256  golang.tar.gz" | sha256sum -c - \

--- a/go/base/install-go.sh
+++ b/go/base/install-go.sh
@@ -4,10 +4,10 @@ set -e
 
 ## These variables are automatically bumped.
 ## If you change their name please change .ci/bump-go-release-version.sh
-GOLANG_VERSION=1.19.5
-GOLANG_DOWNLOAD_URL=https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
-GOLANG_DOWNLOAD_SHA256_AMD=36519702ae2fd573c9869461990ae550c8c0d955cd28d2827a6b159fda81ff95
-GOLANG_DOWNLOAD_SHA256_ARM=fc0aa29c933cec8d76f5435d859aaf42249aa08c74eb2d154689ae44c08d23b3
+GOLANG_VERSION=1.20rc2
+GOLANG_DOWNLOAD_URL=https://go.dev/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
+GOLANG_DOWNLOAD_SHA256_AMD=9ba01a3be1a682b89f5bfc62f9fba0e7d6990a5b7018f6c7aaa56ad65ed96a0e
+GOLANG_DOWNLOAD_SHA256_ARM=d14c1eeb9f48e8def6f886f4cdec57c0a90ba47bdee1b79a00543aa30386e3a6
 
 GO_TAR_FILE=/tmp/golang.tar.gz
 


### PR DESCRIPTION
https://is.go.released.info/ 

<img width="601" alt="image" src="https://user-images.githubusercontent.com/2871786/214791784-3b7b12c3-1d8a-40c8-8c5d-061a3f98c9e2.png">


### Tasks

- [ ] Branch off `1.19` from `main`
- [ ] Update automation to bump 1.19 in https://github.com/elastic/apm-pipeline-library/blob/15602fdc2deeb020c9b67c0ae24bc88f0a2b5fcd/.ci/.bump-go-release-version.yml#L99-L105
- [ ] Notify teams that `1.18` will be EOL shortly
