### PR TITLE
automate bump golang version

### DIFF
--- a/.ci/bump-go-release-version.sh
+++ b/.ci/bump-go-release-version.sh
@@ -3,7 +3,6 @@
 # Given the Golang release version this script will bump the version.
 #
 # This script is executed by the automation we are putting in place
-# and it requires the git add/commit commands.
 #
 # NOTE: sha256 is retrieved from https://pkg.go.dev/golang.org/x/website/internal/dl?utm_source=godoc
 #
@@ -26,9 +25,7 @@ GOLANG_DOWNLOAD_SHA256_AMD=$(curl -s -L https://golang.org/dl/\?mode\=json | jq 
 
 echo "Update go version ${GO_RELEASE_VERSION}"
 ${SED} -E -e "s#(VERSION[[:space:]]+):= .*#\1:= ${GO_RELEASE_VERSION}#g" "go/Makefile.common"
-git add "go/Makefile.common"
 ${SED} -E -e "s#(GO_VERSION[[:space:]]+)= .*#\1= '${GO_RELEASE_VERSION}'#g" Jenkinsfile
-git add Jenkinsfile
 
 find "go" -type f -name Dockerfile.tmpl -print0 |
     while IFS= read -r -d '' line; do
@@ -38,17 +35,10 @@ find "go" -type f -name Dockerfile.tmpl -print0 |
         else
             ${SED} -E -e "s#(ARG GOLANG_DOWNLOAD_SHA256)=.+#\1=${GOLANG_DOWNLOAD_SHA256_AMD}#g" "$line"
         fi
-        git add "${line}"
     done
 
 if [ -e go/base/install-go.sh ] ; then
     ${SED} -E -e "s#(GOLANG_VERSION)=[0-9]+\.[0-9]+(\.[0-9]+)?#\1=${GO_RELEASE_VERSION}#g" go/base/install-go.sh
     ${SED} -E -e "s#(GOLANG_DOWNLOAD_SHA256_AMD)=.+#\1=${GOLANG_DOWNLOAD_SHA256_AMD}#g" go/base/install-go.sh
     ${SED} -E -e "s#(GOLANG_DOWNLOAD_SHA256_ARM)=.+#\1=${GOLANG_DOWNLOAD_SHA256_ARM}#g" go/base/install-go.sh
-    git add go/base/install-go.sh
 fi
-
-git diff --staged --quiet || git commit -m "[Automation] Update go release version to ${GO_RELEASE_VERSION}"
-git --no-pager log -1
-
-echo "You can now push and create a Pull Request"

--- a/.ci/bump-golang.yml
+++ b/.ci/bump-golang.yml
@@ -1,0 +1,59 @@
+---
+name: Bump golang-version to latest version
+
+scms:
+  githubConfig:
+    kind: github
+    spec:
+      user: '{{ requiredEnv "GIT_USER" }}'
+      email: '{{ requiredEnv "GIT_EMAIL" }}'
+      owner: elastic
+      repository: golang-crossbuild
+      token: '{{ requiredEnv "GITHUB_TOKEN" }}'
+      username: '{{ requiredEnv "GIT_USER" }}'
+      branch: '{{ requiredEnv "BRANCH" }}'
+
+actions:
+  golang-crossbuild:
+    kind: github/pullrequest
+    scmid: githubConfig
+    sourceid: latestGoVersion
+    spec:
+      automerge: false
+      labels:
+        - dependencies
+        - backport-skip
+      title: '[Automation] Bump Golang version to {{ source "latestGoVersion" }}'
+
+sources:
+  latestGoVersion:
+    name: Get Latest Go Release
+    kind: githubrelease
+    dependson:
+      - minor
+    transformers:
+      - trimprefix: go
+    spec:
+      owner: golang
+      repository: go
+      token: '{{ requiredEnv "GITHUB_TOKEN" }}'
+      username: '{{ requiredEnv "GIT_USER" }}'
+      versionfilter:
+        kind: regex
+        pattern: go1\.(\d*)(\.(\d*))?$
+
+conditions:
+  dockerTag:
+    name: Is docker image golang:{{ source "latestGoVersion" }} published
+    kind: dockerimage
+    spec:
+      image: golang
+      tag: '{{ source "latestGoVersion" }}'
+    sourceid: latestGoVersion
+
+targets:
+  update-go-versions:
+    kind: shell
+    sourceid: latestGoVersion
+    spec:
+      command: .ci/bump-go-release-version.sh

--- a/.ci/bump-golang.yml
+++ b/.ci/bump-golang.yml
@@ -26,6 +26,16 @@ actions:
       title: '[Automation] Bump Golang version to {{ source "latestGoVersion" }}'
 
 sources:
+  minor:
+    name: Get minor version
+    kind: shell
+    transformers:
+      - findsubmatch:
+          pattern: '^\d+.(\d+)'
+          captureindex: 1
+    spec:
+      command: echo {{ requiredEnv "GO_MINOR" }}
+
   latestGoVersion:
     name: Get Latest Go Release
     kind: githubrelease
@@ -40,7 +50,7 @@ sources:
       username: '{{ requiredEnv "GIT_USER" }}'
       versionfilter:
         kind: regex
-        pattern: go1\.(\d*)(\.(\d*))?$
+        pattern: go1\.{{ source "minor" }}(\.(\d*))?$
 
 conditions:
   dockerTag:
@@ -53,7 +63,9 @@ conditions:
 
 targets:
   update-go-versions:
+    name: "Update go versions"
     kind: shell
     sourceid: latestGoVersion
+    scmid: githubConfig
     spec:
       command: .ci/bump-go-release-version.sh

--- a/.github/workflows/bump-golang-1.18.yml
+++ b/.github/workflows/bump-golang-1.18.yml
@@ -2,6 +2,7 @@
 name: Bump golang version 1.18
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: '0 22 * * 6'
 

--- a/.github/workflows/bump-golang-1.18.yml
+++ b/.github/workflows/bump-golang-1.18.yml
@@ -3,7 +3,7 @@ name: Bump golang version 1.18
 
 on:
   schedule:
-    - cron: '0 21 * * 6'
+    - cron: '0 22 * * 6'
 
 permissions:
   pull-requests: write

--- a/.github/workflows/bump-golang-1.18.yml
+++ b/.github/workflows/bump-golang-1.18.yml
@@ -1,24 +1,21 @@
 ---
-name: Bump golang version
+name: Bump golang version 1.18
 
 on:
   schedule:
-    - cron: '0 20 * * 6'
+    - cron: '0 21 * * 6'
 
 permissions:
   pull-requests: write
   contents: write
 
-env:
-  BRANCH_TO_BE_UPDATED: main
-
 jobs:
-  bump-main:
+  bump-1.18:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: .github/workflows/bump-golang
         with:
-          branch: 'main'
-          go-minor: '1.20'
+          branch: '1.18'
+          go-minor: '1.18'
           token: ${{ github.token }}

--- a/.github/workflows/bump-golang-1.19.yml
+++ b/.github/workflows/bump-golang-1.19.yml
@@ -1,24 +1,21 @@
 ---
-name: Bump golang version
+name: Bump golang version 1.19
 
 on:
   schedule:
-    - cron: '0 20 * * 6'
+    - cron: '0 21 * * 6'
 
 permissions:
   pull-requests: write
   contents: write
 
-env:
-  BRANCH_TO_BE_UPDATED: main
-
 jobs:
-  bump-main:
+  bump-1.19:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: .github/workflows/bump-golang
         with:
-          branch: 'main'
-          go-minor: '1.20'
+          branch: '1.19'
+          go-minor: '1.19'
           token: ${{ github.token }}

--- a/.github/workflows/bump-golang-1.19.yml
+++ b/.github/workflows/bump-golang-1.19.yml
@@ -2,6 +2,7 @@
 name: Bump golang version 1.19
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: '0 21 * * 6'
 

--- a/.github/workflows/bump-golang.yml
+++ b/.github/workflows/bump-golang.yml
@@ -2,6 +2,7 @@
 name: Bump golang version
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: '0 20 * * 6'
 

--- a/.github/workflows/bump-golang.yml
+++ b/.github/workflows/bump-golang.yml
@@ -1,0 +1,41 @@
+---
+name: Bump golang version
+
+on:
+  schedule:
+    - cron: '0 20 * * 6'
+
+permissions:
+  pull-requests: write
+  contents: write
+
+env:
+  BRANCH_TO_BE_UPDATED: main
+
+jobs:
+  bump-main:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: .github/workflows/bump-golang
+        with:
+          branch: 'main'
+          token: ${{ github.token }}
+
+  bump-1.19:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: .github/workflows/bump-golang
+        with:
+          branch: '1.19'
+          token: ${{ github.token }}
+
+  bump-1.18:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: .github/workflows/bump-golang
+        with:
+          branch: '1.18'
+          token: ${{ github.token }}

--- a/.github/workflows/bump-golang.yml
+++ b/.github/workflows/bump-golang.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: .github/workflows/bump-golang
         with:
           branch: 'main'
+          go-minor: '1.20'
           token: ${{ github.token }}
 
   bump-1.19:
@@ -29,6 +30,7 @@ jobs:
       - uses: .github/workflows/bump-golang
         with:
           branch: '1.19'
+          go-minor: '1.19'
           token: ${{ github.token }}
 
   bump-1.18:
@@ -38,4 +40,5 @@ jobs:
       - uses: .github/workflows/bump-golang
         with:
           branch: '1.18'
+          go-minor: '1.18'
           token: ${{ github.token }}

--- a/.github/workflows/bump-golang/action.yml
+++ b/.github/workflows/bump-golang/action.yml
@@ -4,6 +4,9 @@ inputs:
   branch:
     description: 'What branch'
     required: true
+  go-minor:
+    description: 'What Go minor version ([0-9]+.[0.9]+)'
+    required: true
   token:
     description: 'What github token'
     default: ${{ github.token }}
@@ -25,5 +28,6 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.token }}
         BRANCH: ${{ inputs.branch }}
+        GO_MINOR: ${{ inputs.go-minor }}
       run: updatecli apply --config ./.ci/bump-golang.yml
       shell: bash

--- a/.github/workflows/bump-golang/action.yml
+++ b/.github/workflows/bump-golang/action.yml
@@ -1,0 +1,29 @@
+---
+name: common build tasks
+inputs:
+  branch:
+    description: 'What branch'
+    required: true
+  token:
+    description: 'What github token'
+    default: ${{ github.token }}
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: ${{ inputs.branch }}
+
+    - name: Setup Git
+      uses: elastic/apm-pipeline-library/.github/actions/setup-git@current
+
+    - name: Install Updatecli in the runner
+      uses: updatecli/updatecli-action@453502948b442d7b9a923de7b40cc7ce8628505c
+
+    - name: Run Updatecli
+      env:
+        GITHUB_TOKEN: ${{ inputs.token }}
+        BRANCH: ${{ inputs.branch }}
+      run: updatecli apply --config ./.ci/bump-golang.yml
+      shell: bash


### PR DESCRIPTION
## What does this PR do?

Automate the golang bump within the project itself using [updatecli](https://www.updatecli.io/) and github actions

## Why is it important?

Remove the dependency with Jenkins and the definition of what to do in [apm-pipeline-library](https://github.com/elastic/apm-pipeline-library/blob/a3850732518748f2e71815c093d58cb071d0d8a3/.ci/.bump-go-release-version.yml#L33-L40)

Use updatecli that provides the tooling for bumping versions

## Further details

There will be one GitHub workflow per active Golang minor version.