### PR TITLE
updatecli: use condition to fix shell action idempotence

### DIFF
--- a/.ci/bump-golang.yml
+++ b/.ci/bump-golang.yml
@@ -60,6 +60,12 @@ conditions:
       image: golang
       tag: '{{ source "latestGoVersion" }}'
     sourceid: latestGoVersion
+  is:
+    name: Is version '{{ source "latestGoVersion" }}' not updated in 'go/Makefile.common'?
+    kind: shell
+    spec:
+      command: 'grep -v -q {{ source "latestGoVersion" }} go/Makefile.common #'
+    sourceid: latestGoVersion
 
 targets:
   update-go-versions:


### PR DESCRIPTION
Shell actions in `updatecli` require some specific implementation see https://www.updatecli.io/docs/plugins/resource/shell/#_shell_target


Hence, the condition will ensure no changes need to be applied in the latest release matches the one in the file `go/Makefile.common`.

Fixes https://github.com/elastic/golang-crossbuild/issues/265