### PR TITLE
mergify/updatecli: delete branches and add changelog URL

### DIFF
--- a/.ci/bump-golang.yml
+++ b/.ci/bump-golang.yml
@@ -25,6 +25,8 @@ actions:
         - dependencies
         - backport-skip
       title: '[Automation] Bump Golang version to {{ source "latestGoVersion" }}'
+      description: |
+        See [changelog](https://github.com/golang/go/issues?q=milestone%3AGo{{ source "latestGoVersion" }}+label%3ACherryPickApproved) for {{ source "latestGoVersion" }}
 
 sources:
   minor:

--- a/.ci/bump-golang.yml
+++ b/.ci/bump-golang.yml
@@ -1,5 +1,6 @@
 ---
 name: Bump golang-version to latest version
+pipelineid: 'bump-golang-version-{{ requiredEnv "BRANCH" }}'
 
 scms:
   githubConfig:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -6,7 +6,7 @@ pull_request_rules:
         - closed
       - and:
         - label=automation
-        - head~=^update-go-version
+        - head~=^updatecli
         - files~=^Jenkinsfile$
     actions:
       delete_head_branch:


### PR DESCRIPTION
When we added the `updatecli` the mergify automation was not changed accordingly, hence the branches are piled up.