### PR TITLE
enable Debian 12 and bump llvm version to swift-5.6.3 

### DIFF
--- a/.ci/llvm-apple.groovy
+++ b/.ci/llvm-apple.groovy
@@ -64,7 +64,7 @@ pipeline {
         axes {
           axis {
             name 'DEBIAN_VERSION'
-            values '10', '11'
+            values '10', '11', '12'
           }
           axis {
             name 'AGENT_LABELS'

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -44,6 +44,7 @@ template: |
   - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-main-debian9` - linux/i386, linux/amd64, windows/386, windows/amd64
   - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-main-debian10` - linux/i386, linux/amd64, windows/386, windows/amd64
   - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-main-debian11` - linux/i386, linux/amd64, windows/386, windows/amd64
+  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-main-debian12` - linux/i386, linux/amd64, windows/386, windows/amd64
   - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-mips` - linux/mips64, linux/mips64el
   - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-mips32` - linux/mips, linux/mipsle
   - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-ppc` - linux/ppc64, linux/ppc64le

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -61,7 +61,7 @@ pipeline {
         axes {
           axis {
             name 'MAKEFILE'
-            values 'Makefile', 'Makefile.debian7', 'Makefile.debian8', 'Makefile.debian9', 'Makefile.debian10', 'Makefile.debian11'
+            values 'Makefile', 'Makefile.debian7', 'Makefile.debian8', 'Makefile.debian9', 'Makefile.debian10', 'Makefile.debian11', 'Makefile.debian12'
           }
           axis {
             name 'PLATFORM'
@@ -117,6 +117,16 @@ pipeline {
             axis {
               name 'MAKEFILE'
               values 'Makefile.debian11'
+            }
+          }
+          exclude {
+            axis {
+              name 'PLATFORM'
+              values 'arm'
+            }
+            axis {
+              name 'MAKEFILE'
+              values 'Makefile.debian12'
             }
           }
         }

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,8 @@ build:
 		$(MAKE) -C $(var) -f Makefile.debian8 $@ || echo '1' > ${status}; \
 		$(MAKE) -C $(var) -f Makefile.debian9 $@ || echo '1' > ${status}; \
 		$(MAKE) -C $(var) -f Makefile.debian10 $@ || echo '1' > ${status}; \
-		$(MAKE) -C $(var) -f Makefile.debian11 $@ || echo '1' > ${status})
+		$(MAKE) -C $(var) -f Makefile.debian11 $@ || echo '1' > ${status}; \
+		$(MAKE) -C $(var) -f Makefile.debian12 $@ || echo '1' > ${status})
 	@make -C fpm $@ || echo '1' > ${status}
 	exit $$(cat ${status})
 
@@ -36,7 +37,8 @@ push:
 		$(MAKE) -C $(var) -f Makefile.debian8 $@ || echo '1' > ${status}; \
 		$(MAKE) -C $(var) -f Makefile.debian9 $@ || echo '1' > ${status}; \
 		$(MAKE) -C $(var) -f Makefile.debian10 $@ || echo '1' > ${status}; \
-		$(MAKE) -C $(var) -f Makefile.debian11 $@ || echo '1' > ${status})
+		$(MAKE) -C $(var) -f Makefile.debian11 $@ || echo '1' > ${status}; \
+		$(MAKE) -C $(var) -f Makefile.debian12 $@ || echo '1' > ${status})
 	@make -C fpm $@ || echo '1' > ${status}
 	exit $$(cat ${status})
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Replace `<GOLANG_VERSION>` with the version you would like to use, for instance:
 - `docker.elastic.co/beats-dev/golang-crossbuild:<GOLANG_VERSION>-main-debian9` - linux/i386, linux/amd64, windows/386, windows/amd64
 - `docker.elastic.co/beats-dev/golang-crossbuild:<GOLANG_VERSION>-main-debian10` - linux/i386, linux/amd64, windows/386, windows/amd64
 - `docker.elastic.co/beats-dev/golang-crossbuild:<GOLANG_VERSION>-main-debian11` - linux/i386, linux/amd64, windows/386, windows/amd64
+- `docker.elastic.co/beats-dev/golang-crossbuild:<GOLANG_VERSION>-main-debian12` - linux/i386, linux/amd64, windows/386, windows/amd64
 - `docker.elastic.co/beats-dev/golang-crossbuild:<GOLANG_VERSION>-mips` - linux/mips64, linux/mips64el
 - `docker.elastic.co/beats-dev/golang-crossbuild:<GOLANG_VERSION>-mips32` - linux/mips, linux/mipsle
 - `docker.elastic.co/beats-dev/golang-crossbuild:<GOLANG_VERSION>-ppc` - linux/ppc64, linux/ppc64le

--- a/go/Makefile.debian12
+++ b/go/Makefile.debian12
@@ -1,0 +1,14 @@
+IMAGES         := base main darwin arm armhf armel mips ppc s390x darwin-arm64 npcap
+DEBIAN_VERSION := 12
+TAG_EXTENSION  := -debian12
+
+export DEBIAN_VERSION TAG_EXTENSION
+
+build:
+	@$(foreach var,$(IMAGES),$(MAKE) -C $(var) build || exit 1;)
+
+# Requires login at https://docker.elastic.co:7000/.
+push:
+	@$(foreach var,$(IMAGES),$(MAKE) -C $(var) push || exit 1;)
+
+.PHONY: build push

--- a/go/arm/Dockerfile.tmpl
+++ b/go/arm/Dockerfile.tmpl
@@ -36,7 +36,7 @@ RUN apt install -y \
         libsystemd-dev:arm64 libsystemd0:arm64 liblz4-1:arm64
 {{- end }}
 
-{{- if or (eq .DEBIAN_VERSION "10") (eq .DEBIAN_VERSION "11")}}
+{{- if or (eq .DEBIAN_VERSION "10") (eq .DEBIAN_VERSION "11") (eq .DEBIAN_VERSION "12")}}
 # librpm-dev
 RUN apt install -y \
         librpm-dev:arm64
@@ -81,7 +81,7 @@ RUN apt install -y \
         libsystemd-dev libsystemd0 liblz4-1
 {{- end }}
 
-{{- if or (eq .DEBIAN_VERSION "10") (eq .DEBIAN_VERSION "11")}}
+{{- if or (eq .DEBIAN_VERSION "10") (eq .DEBIAN_VERSION "11") (eq .DEBIAN_VERSION "12")}}
 # librpm-dev
 RUN apt install -y \
         librpm-dev

--- a/go/armel/Dockerfile.tmpl
+++ b/go/armel/Dockerfile.tmpl
@@ -36,7 +36,7 @@ RUN apt install -y \
         libsystemd-dev:armel libsystemd0:armel liblz4-1:armel
 {{- end }}
 
-{{- if or (eq .DEBIAN_VERSION "10") (eq .DEBIAN_VERSION "11")}}
+{{- if or (eq .DEBIAN_VERSION "10") (eq .DEBIAN_VERSION "11") (eq .DEBIAN_VERSION "12")}}
 # librpm-dev
 RUN apt install -y \
         librpm-dev:armel

--- a/go/armhf/Dockerfile.tmpl
+++ b/go/armhf/Dockerfile.tmpl
@@ -36,7 +36,7 @@ RUN apt install -y \
         libsystemd-dev:armhf libsystemd0:armhf liblz4-1:armhf
 {{- end }}
 
-{{- if or (eq .DEBIAN_VERSION "10") (eq .DEBIAN_VERSION "11")}}
+{{- if or (eq .DEBIAN_VERSION "10") (eq .DEBIAN_VERSION "11") (eq .DEBIAN_VERSION "12")}}
 # librpm-dev
 RUN apt install -y \
         librpm-dev:armhf

--- a/go/base/Dockerfile.tmpl
+++ b/go/base/Dockerfile.tmpl
@@ -18,7 +18,7 @@ RUN apt-get -o Acquire::Check-Valid-Until=false update -y --no-install-recommend
             file \
             flex \
             bison \
-{{- if or (eq .DEBIAN_VERSION "10") (eq .DEBIAN_VERSION "11")}}
+{{- if or (eq .DEBIAN_VERSION "10") (eq .DEBIAN_VERSION "11") (eq .DEBIAN_VERSION "12")}}
             binutils-multiarch \
             binutils-multiarch-dev \
             python3-venv \

--- a/go/base/sources-debian12.list
+++ b/go/base/sources-debian12.list
@@ -1,0 +1,3 @@
+# see https://wiki.debian.org/CrossToolchains
+deb http://deb.debian.org/debian bookworm main
+deb http://deb.debian.org/debian-security/ bookworm-security main

--- a/go/darwin-arm64/Dockerfile.tmpl
+++ b/go/darwin-arm64/Dockerfile.tmpl
@@ -1,7 +1,7 @@
 ARG REPOSITORY
 ARG VERSION
 ARG TAG_EXTENSION=''
-{{- if or (eq .DEBIAN_VERSION "10") (eq .DEBIAN_VERSION "11")}}
+{{- if or (eq .DEBIAN_VERSION "10") (eq .DEBIAN_VERSION "11") (eq .DEBIAN_VERSION "12")}}
 FROM --platform=linux/amd64  docker.elastic.co/beats-dev/golang-crossbuild:llvm-apple-debian{{ .DEBIAN_VERSION }}-amd64 AS build-llvm-apple-amd64
 FROM --platform=linux/arm64  docker.elastic.co/beats-dev/golang-crossbuild:llvm-apple-debian{{ .DEBIAN_VERSION }}-arm64 AS build-llvm-apple-arm64
 # workaround to https://github.com/moby/moby/issues/34482
@@ -14,7 +14,7 @@ RUN echo "Building ${TARGETARCH} on a ${BUILDARCH}"
 {{- end }}
 FROM ${REPOSITORY}/golang-crossbuild:${VERSION}-base${TAG_EXTENSION}
 
-{{- if and (ne .DEBIAN_VERSION "10") (ne .DEBIAN_VERSION "11")}}
+{{- if and (ne .DEBIAN_VERSION "10") (ne .DEBIAN_VERSION "11") (ne .DEBIAN_VERSION "12")}}
 RUN echo "This Docker image will work only with Debian >10" && exit 1
 {{- end }}
 

--- a/go/darwin/Dockerfile.tmpl
+++ b/go/darwin/Dockerfile.tmpl
@@ -2,7 +2,7 @@ ARG REPOSITORY
 ARG VERSION
 ARG TAG_EXTENSION=''
 
-{{- if or (eq .DEBIAN_VERSION "10") (eq .DEBIAN_VERSION "11")}}
+{{- if or (eq .DEBIAN_VERSION "10") (eq .DEBIAN_VERSION "11") (eq .DEBIAN_VERSION "12")}}
 FROM --platform=linux/amd64  docker.elastic.co/beats-dev/golang-crossbuild:llvm-apple-debian{{ .DEBIAN_VERSION }}-amd64 AS build-llvm-apple-amd64
 FROM --platform=linux/arm64  docker.elastic.co/beats-dev/golang-crossbuild:llvm-apple-debian{{ .DEBIAN_VERSION }}-arm64 AS build-llvm-apple-arm64
 # workaround to https://github.com/moby/moby/issues/34482
@@ -22,7 +22,7 @@ RUN \
         llvm \
         cmake \
         patch \
-{{- if and (ne .DEBIAN_VERSION "10") (ne .DEBIAN_VERSION "11")}}
+{{- if and (ne .DEBIAN_VERSION "10") (ne .DEBIAN_VERSION "11") (ne .DEBIAN_VERSION "12") }}
         python \
 {{- end }}
         libssl-dev \
@@ -32,7 +32,7 @@ RUN \
         uuid-dev \
     && rm -rf /var/lib/apt/lists/*
 
-{{- if or (eq .DEBIAN_VERSION "10") (eq .DEBIAN_VERSION "11")}}
+{{- if or (eq .DEBIAN_VERSION "10") (eq .DEBIAN_VERSION "11") (eq .DEBIAN_VERSION "12") }}
 ARG OSXCROSS_PATH=/usr/local/osxcross
 COPY --from=build-llvm-apple /osxcross.tar.gz /tmp/osxcross.tar.gz
 RUN tar -xzf /tmp/osxcross.tar.gz -C / \
@@ -66,7 +66,7 @@ RUN cd / \
   && file helloWorld.x86_64 \
   && file helloWorld.x86_64 | grep -c 'Mach-O 64-bit x86_64'
 
-{{- if or (eq .DEBIAN_VERSION "10") (eq .DEBIAN_VERSION "11")}}
+{{- if or (eq .DEBIAN_VERSION "10") (eq .DEBIAN_VERSION "11") (eq .DEBIAN_VERSION "12")}}
 RUN cd / \
   && oa64-clang helloWorld.c -o helloWorld.arm64 \
   && file helloWorld.arm64 \
@@ -79,7 +79,7 @@ RUN cd / \
 {{- end }}
 
 # MacOSX10.14 SDK does not have 32bits compiler
-{{- if and (ne .DEBIAN_VERSION "10") (ne .DEBIAN_VERSION "11")}}
+{{- if and (ne .DEBIAN_VERSION "10") (ne .DEBIAN_VERSION "11") (ne .DEBIAN_VERSION "12")}}
 RUN cd / \
   && o32-clang helloWorld.c -o helloWorld.i368 \
   && file helloWorld.i368 \

--- a/go/llvm-apple/Dockerfile.tmpl
+++ b/go/llvm-apple/Dockerfile.tmpl
@@ -32,7 +32,7 @@ RUN apt-get -o Acquire::Check-Valid-Until=false update -y --no-install-recommend
 #https://www.llvm.org/docs/CMake.html
 #https://github.com/apple/llvm-project
 RUN mkdir -p /tmp/llvm-project && cd /tmp/llvm-project \
-    && curl -sSL "https://github.com/apple/llvm-project/archive/refs/tags/swift-5.4.1-RELEASE.tar.gz" \
+    && curl -sSL "https://github.com/apple/llvm-project/archive/refs/tags/swift-5.6.3-RELEASE.tar.gz" \
       | tar -C /tmp/llvm-project --strip=1 -xzf - \
     && mkdir build && cd build \
     && cmake -DLLVM_ENABLE_PROJECTS="clang" \

--- a/go/llvm-apple/Dockerfile.tmpl
+++ b/go/llvm-apple/Dockerfile.tmpl
@@ -20,7 +20,7 @@ RUN apt-get -o Acquire::Check-Valid-Until=false update -y --no-install-recommend
             libxml2-dev \
             lzma-dev \
             uuid-dev \
-{{- if or (eq .DEBIAN_VERSION "10") (eq .DEBIAN_VERSION "11")}}
+{{- if or (eq .DEBIAN_VERSION "10") (eq .DEBIAN_VERSION "11") (eq .DEBIAN_VERSION "12")}}
             binutils-multiarch \
             binutils-multiarch-dev \
             python3-venv \

--- a/go/main/Dockerfile.tmpl
+++ b/go/main/Dockerfile.tmpl
@@ -32,7 +32,7 @@ RUN apt install -y --no-install-recommends --allow-unauthenticated\
          libsystemd-dev
 {{- end }}
 
-{{- if or (eq .DEBIAN_VERSION "9") (eq .DEBIAN_VERSION "10") (eq .DEBIAN_VERSION "11") }}
+{{- if or (eq .DEBIAN_VERSION "9") (eq .DEBIAN_VERSION "10") (eq .DEBIAN_VERSION "11") (eq .DEBIAN_VERSION "12")}}
 # msitools
 RUN apt install -y --no-install-recommends --allow-unauthenticated\
          msitools

--- a/go/mips/Dockerfile.tmpl
+++ b/go/mips/Dockerfile.tmpl
@@ -43,7 +43,7 @@ RUN apt install -y \
 #         libsystemd-dev:mips64el libsystemd0:mips64el liblz4-1:mips64el
 {{- end }}
 
-{{- if or (eq .DEBIAN_VERSION "10") (eq .DEBIAN_VERSION "11")}}
+{{- if or (eq .DEBIAN_VERSION "10") (eq .DEBIAN_VERSION "11") (eq .DEBIAN_VERSION "12")}}
 # librpm-dev
 RUN apt install -y \
         librpm-dev:mips64el

--- a/go/mips32/Dockerfile.tmpl
+++ b/go/mips32/Dockerfile.tmpl
@@ -41,7 +41,7 @@ RUN apt install -y \
 #         libsystemd-dev:mips libsystemd0:mips liblz4-1:mips
 {{- end }}
 
-{{- if or (eq .DEBIAN_VERSION "10") (eq .DEBIAN_VERSION "11")}}
+{{- if or (eq .DEBIAN_VERSION "10") (eq .DEBIAN_VERSION "11") (eq .DEBIAN_VERSION "12")}}
 # librpm-dev
 RUN apt install -y \
         librpm-dev:mips

--- a/go/ppc/Dockerfile.tmpl
+++ b/go/ppc/Dockerfile.tmpl
@@ -37,7 +37,7 @@ RUN apt install -qq -y \
 #         libsystemd-dev:ppc64el libsystemd0:ppc64el liblz4-1:ppc64el
 {{- end }}
 
-{{- if or (eq .DEBIAN_VERSION "10") (eq .DEBIAN_VERSION "11")}}
+{{- if or (eq .DEBIAN_VERSION "10") (eq .DEBIAN_VERSION "11") (eq .DEBIAN_VERSION "12")}}
 # librpm-dev
 RUN apt install -y \
         librpm-dev:ppc64el

--- a/go/s390x/Dockerfile.tmpl
+++ b/go/s390x/Dockerfile.tmpl
@@ -36,7 +36,7 @@ RUN apt install -qq -y \
 #         libsystemd-dev:s390x libsystemd0:s390x liblz4-1:s390x
 {{- end }}
 
-{{- if or (eq .DEBIAN_VERSION "10") (eq .DEBIAN_VERSION "11")}}
+{{- if or (eq .DEBIAN_VERSION "10") (eq .DEBIAN_VERSION "11") (eq .DEBIAN_VERSION "12")}}
 # librpm-dev
 RUN apt install -y \
         librpm-dev:s390x


### PR DESCRIPTION
### What

Does what it says in the tin.

### Why

`Debian 12` has been released early June 2023: https://www.debian.org/News/2023/20230610

### Issues

Requires https://github.com/debuerreotype/docker-debian-artifacts/issues/196

### Implementation details

`Debian 12` is needed to be added in some of the Dockerfile templates so the packages are installed for that particular version. For such, I looked for `debian 11` and added the condition for `debian 12`

llvm for `Debian 12` is also required, hence [llvm-apple-mbp](https://beats-ci.elastic.co/job/golang-crossbuild/job/llvm-apple-mbp/) needs to be triggered too.

llvm for `Debian 12` failed with some missing imports, see https://reviews.llvm.org/D89450 and https://github.com/elastic/golang-crossbuild/pull/298#issuecomment-1589596842, so it was required to bump the version for https://github.com/apple/llvm-project to [swift-5.6.3-RELEASE](https://github.com/apple/llvm-project/archive/refs/tags/swift-5.6.3-RELEASE.tar.gz).

Once [llvm-apple-mpb@PR-298](https://beats-ci.elastic.co/job/golang-crossbuild/job/llvm-apple-mbp/view/change-requests/job/PR-298/) is finished, we could manually re-tag those docker images for `Debian 12` so it can be consumed accordingly.

Otherwise

```bash
$ make -C go -f Makefile.debian12 build
...
...
>> Building docker.elastic.co/beats-dev/golang-crossbuild:1.20.5-darwin-debian12
[+] Building 1.9s (5/5) FINISHED                                                                                                                                                                                                                              
 => [internal] load build definition from Dockerfile                                                                                                                                                                                                     0.0s
 => => transferring dockerfile: 2.22kB                                                                                                                                                                                                                   0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                                        0.0s
 => => transferring context: 2B                                                                                                                                                                                                                          0.0s
 => ERROR [internal] load metadata for docker.elastic.co/beats-dev/golang-crossbuild:llvm-apple-debian12-amd64                                                                                                                                           1.8s
 => [internal] load metadata for docker.elastic.co/beats-dev/golang-crossbuild:1.20.5-base-debian12                                                                                                                                                      0.0s
 => [auth] beats-dev/golang-crossbuild:pull token for docker.elastic.co                                                                                                                                                                                  0.0s
------
 > [internal] load metadata for docker.elastic.co/beats-dev/golang-crossbuild:llvm-apple-debian12-amd64:
------
failed to solve with frontend dockerfile.v0: failed to create LLB definition: docker.elastic.co/beats-dev/golang-crossbuild:llvm-apple-debian12-amd64: not found
make[1]: *** [build] Error 1
make: *** [build] Error 1
```

Then

```bash
$ docker pull docker.elastic.co/observability-ci/golang-crossbuild:llvm-apple-debian12-amd64 
$ docker tag docker.elastic.co/observability-ci/golang-crossbuild:llvm-apple-debian12-amd64 docker.elastic.co/beats-dev/golang-crossbuild:llvm-apple-debian12-amd64
$ docker push docker.elastic.co/beats-dev/golang-crossbuild:llvm-apple-debian12-amd64
$ docker pull docker.elastic.co/observability-ci/golang-crossbuild:llvm-apple-debian12-arm64 
$ docker tag docker.elastic.co/observability-ci/golang-crossbuild:llvm-apple-debian12-arm64 docker.elastic.co/beats-dev/golang-crossbuild:llvm-apple-debian12-arm64
$ docker push docker.elastic.co/beats-dev/golang-crossbuild:llvm-apple-debian12-arm64
```

And I re-triggered the MBP build for this PR.