### PR TITLE
release notes: add docker image suffixes

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -34,8 +34,19 @@ template: |
   ## Go $RESOLVED_VERSION
 
   - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-arm` - linux/arm64
+  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-arm-debian9` - linux/armv5, linux/armv6
+  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-arm-debian10` - linux/armv5, linux/armv6
+  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-arm-debian11` - linux/armv5, linux/armv6
+  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-arm-debian12` - linux/armv5, linux/armv6
   - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-armel` - linux/armv5, linux/armv6
+  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-armel-debian9` - linux/armv5, linux/armv6
+  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-armel-debian11` - linux/armv5, linux/armv6
+  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-armel-debian12` - linux/armv5, linux/armv6
   - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-armhf` - linux/armv7
+  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-armhf-debian9` - linux/armv7
+  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-armhf-debian10` - linux/armv7
+  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-armhf-debian11` - linux/armv7
+  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-armhf-debian12` - linux/armv7
   - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-base`
   - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-darwin` - darwin/amd64 (MacOS 10.11, MacOS 10.14)
   - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-main` - linux/i386, linux/amd64, windows/386, windows/amd64
@@ -45,10 +56,12 @@ template: |
   - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-main-debian10` - linux/i386, linux/amd64, windows/386, windows/amd64
   - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-main-debian11` - linux/i386, linux/amd64, windows/386, windows/amd64
   - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-main-debian12` - linux/i386, linux/amd64, windows/386, windows/amd64
-  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-mips` - linux/mips64, linux/mips64el
-  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-mips32` - linux/mips, linux/mipsle
-  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-ppc` - linux/ppc64, linux/ppc64le
-  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-s390x` - linux/s390x
+  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-mips-debian11` - linux/mips64, linux/mips64el
+  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-mips-debian12` - linux/mips64, linux/mips64el
+  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-ppc-debian11` - linux/ppc64, linux/ppc64le
+  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-ppc-debian12` - linux/ppc64, linux/ppc64le
+  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-s390x-debian11` - linux/s390x
+  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-s390x-debian12` - linux/s390x
 
   ### Changes
 

--- a/README.md
+++ b/README.md
@@ -34,10 +34,13 @@ Replace `<GOLANG_VERSION>` with the version you would like to use, for instance:
 - `docker.elastic.co/beats-dev/golang-crossbuild:<GOLANG_VERSION>-main-debian10` - linux/i386, linux/amd64, windows/386, windows/amd64
 - `docker.elastic.co/beats-dev/golang-crossbuild:<GOLANG_VERSION>-main-debian11` - linux/i386, linux/amd64, windows/386, windows/amd64
 - `docker.elastic.co/beats-dev/golang-crossbuild:<GOLANG_VERSION>-main-debian12` - linux/i386, linux/amd64, windows/386, windows/amd64
-- `docker.elastic.co/beats-dev/golang-crossbuild:<GOLANG_VERSION>-mips` - linux/mips64, linux/mips64el
-- `docker.elastic.co/beats-dev/golang-crossbuild:<GOLANG_VERSION>-mips32` - linux/mips, linux/mipsle
-- `docker.elastic.co/beats-dev/golang-crossbuild:<GOLANG_VERSION>-ppc` - linux/ppc64, linux/ppc64le
-- `docker.elastic.co/beats-dev/golang-crossbuild:<GOLANG_VERSION>-s390x` - linux/s390x
+- `docker.elastic.co/beats-dev/golang-crossbuild:<GOLANG_VERSION>-mips-debian11` - linux/mips64, linux/mips64el
+- `docker.elastic.co/beats-dev/golang-crossbuild:<GOLANG_VERSION>-mips-debian12` - linux/mips64, linux/mips64el
+- `docker.elastic.co/beats-dev/golang-crossbuild:<GOLANG_VERSION>-mips32` - linux/mips, linux/mipsle **NOTE**: it does not exist from Golang versions > `1.18.5`/`1.17.12`.
+- `docker.elastic.co/beats-dev/golang-crossbuild:<GOLANG_VERSION>-ppc-debian11` - linux/ppc64, linux/ppc64le
+- `docker.elastic.co/beats-dev/golang-crossbuild:<GOLANG_VERSION>-ppc-debian12` - linux/ppc64, linux/ppc64le
+- `docker.elastic.co/beats-dev/golang-crossbuild:<GOLANG_VERSION>-s390x-debian11` - linux/s390x
+- `docker.elastic.co/beats-dev/golang-crossbuild:<GOLANG_VERSION>-s390x-debian12` - linux/s390x
 
 **Debian7** uses `glibc 2.13` so the resulting binaries (if dynamically linked) have greater compatibility.
 **Debian8** uses `glibc 2.19`.


### PR DESCRIPTION
Closes https://github.com/elastic/golang-crossbuild/issues/295

Release Drafter and REAMDE.md will include the name of the docker images for the different Debian versions supported.
