### PR TITLE
[Automation] Bump Golang version to 1.19.12

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,7 @@ pipeline {
     DOCKER_REGISTRY_SECRET = 'secret/observability-team/ci/docker-registry/prod'
     DOCKER_REGISTRY = 'docker.elastic.co'
     STAGING_IMAGE = "${env.DOCKER_REGISTRY}/observability-ci"
-    GO_VERSION = '1.19.11'
+    GO_VERSION = '1.19.12'
     BUILDX = "1"
   }
   options {

--- a/go/Makefile.common
+++ b/go/Makefile.common
@@ -2,7 +2,7 @@ SELF_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 include $(SELF_DIR)/../Makefile.common
 
 NAME           := golang-crossbuild
-VERSION        := 1.19.11
+VERSION        := 1.19.12
 DEBIAN_VERSION ?= 9
 SUFFIX         := -$(shell basename $(CURDIR))
 TAG_EXTENSION  ?=

--- a/go/base-arm/Dockerfile.tmpl
+++ b/go/base-arm/Dockerfile.tmpl
@@ -37,9 +37,9 @@ RUN \
             libsqlite3-0 \
         && rm -rf /var/lib/apt/lists/*
 
-ARG GOLANG_VERSION=1.19.11
+ARG GOLANG_VERSION=1.19.12
 ARG GOLANG_DOWNLOAD_URL=https://golang.org/dl/go$GOLANG_VERSION.linux-arm64.tar.gz
-ARG GOLANG_DOWNLOAD_SHA256=ae22c047e0e63d2d28205b529baaf9d9ca0c93e890c309af62cd116b9efebcbd
+ARG GOLANG_DOWNLOAD_SHA256=18da7cf1ae5341e6ee120948221aff96df9145ce70f429276514ca7c67c929b1
 
 RUN curl -fsSL "$GOLANG_DOWNLOAD_URL" -o golang.tar.gz \
 	&& echo "$GOLANG_DOWNLOAD_SHA256  golang.tar.gz" | sha256sum -c - \

--- a/go/base/install-go.sh
+++ b/go/base/install-go.sh
@@ -4,10 +4,10 @@ set -e
 
 ## These variables are automatically bumped.
 ## If you change their name please change .ci/bump-go-release-version.sh
-GOLANG_VERSION=1.19.11
+GOLANG_VERSION=1.19.12
 GOLANG_DOWNLOAD_URL=https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
-GOLANG_DOWNLOAD_SHA256_AMD=ee18f98a03386e2bf48ff75737ea17c953b1572f9b1114352f104ac5eef04bb4
-GOLANG_DOWNLOAD_SHA256_ARM=ae22c047e0e63d2d28205b529baaf9d9ca0c93e890c309af62cd116b9efebcbd
+GOLANG_DOWNLOAD_SHA256_AMD=48e4fcfb6abfdaa01aaf1429e43bdd49cea5e4687bd5f5b96df1e193fcfd3e7e
+GOLANG_DOWNLOAD_SHA256_ARM=18da7cf1ae5341e6ee120948221aff96df9145ce70f429276514ca7c67c929b1
 
 GO_TAR_FILE=/tmp/golang.tar.gz
 


### PR DESCRIPTION


See [changelog](https://github.com/golang/go/issues?q=milestone%3AGo1.19.12+label%3ACherryPickApproved) for 1.19.12


---



<Actions>
    <action id="428fe48e5a6b8b833823486196c9f76dcadda8bee0014ac56d8d16249ae4475c">
        <h3>Bump golang-version to latest version</h3>
        <details id="226c7073ca2786d439fbbe0bf13d2b5523040d4801dfca93d49ece1280917dd3">
            <summary>Update go version 1.19.12</summary>
            <p>ran shell command &#34;.ci/bump-go-release-version.sh 1.19.12&#34;</p>
            <details>
                <summary>1.19.12</summary>
                <pre>no GitHub Release found for go1.19.12 on &#34;https://github.com/golang/go&#34;</pre>
            </details>
        </details>
    </action>
</Actions>

---

<table>
  <tr>
    <td width="77">
      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50">
    </td>
    <td>
      <p>
        Created automatically by <a href="https://www.updatecli.io/">Updatecli</a>
      </p>
      <details><summary>Options:</summary>
        <br />
        <p>Most of Updatecli configuration is done via <a href="https://www.updatecli.io/docs/prologue/quick-start/">its manifest(s)</a>.</p>
        <ul>
          <li>If you close this pull request, Updatecli will automatically reopen it, the next time it runs.</li>
          <li>If you close this pull request and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
        </ul>
        <p>
          Feel free to report any issues at <a href="https://github.com/updatecli/updatecli/issues">github.com/updatecli/updatecli</a>.<br />
          If you find this tool useful, do not hesitate to star <a href="https://github.com/updatecli/updatecli/stargazers">our GitHub repository</a> as a sign of appreciation, and/or to tell us directly on our <a href="https://matrix.to/#/#Updatecli_community:gitter.im">chat</a>!
        </p>
      </details>
    </td>
  </tr>
</table>

