### PR TITLE
Fix debian 11 arm and main docker build

### DIFF
--- a/go/arm/Dockerfile.tmpl
+++ b/go/arm/Dockerfile.tmpl
@@ -4,10 +4,10 @@ ARG TAG_EXTENSION=''
 FROM --platform=linux/amd64 ${REPOSITORY}/golang-crossbuild:${VERSION}-base${TAG_EXTENSION} as stage-amd64
 
 RUN dpkg --add-architecture arm64 \
-    && apt update -y --no-install-recommends \
-    && apt upgrade -y --no-install-recommends \
-    && apt full-upgrade -y --no-install-recommends \
-    && apt install -qq -y --no-install-recommends \
+        && apt update -y --no-install-recommends \
+        && apt upgrade -y --no-install-recommends \
+        && apt full-upgrade -y --no-install-recommends \
+        && apt install -qq -y --no-install-recommends \
         crossbuild-essential-arm64 \
         linux-libc-dev-arm64-cross
 
@@ -32,13 +32,18 @@ RUN apt install -y \
         libsqlite3-0:arm64
 
 # libsystemd-dev
-RUN apt install -y \
+RUN apt install -y --fix-broken \
         libsystemd-dev:arm64 libsystemd0:arm64 liblz4-1:arm64
 {{- end }}
 
+{{- if eq .DEBIAN_VERSION "11"}}
+RUN apt update --install-suggests --fix-broken \
+        && apt install -y \
+        libsystemd0:arm64=247.3-7+deb11u2
+{{- end }}
+
 {{- if or (eq .DEBIAN_VERSION "10") (eq .DEBIAN_VERSION "11") (eq .DEBIAN_VERSION "12")}}
-# librpm-dev
-RUN apt install -y \
+RUN apt install -y --install-suggests \
         librpm-dev:arm64
 
 # libsystemd-dev
@@ -51,11 +56,12 @@ ARG VERSION
 ARG TAG_EXTENSION=''
 FROM --platform=linux/arm64 ${REPOSITORY}/golang-crossbuild:${VERSION}-base${TAG_EXTENSION} as stage-arm64
 
+
 RUN dpkg --add-architecture arm64 \
-    && apt update -y --no-install-recommends \
-    && apt upgrade -y --no-install-recommends \
-    && apt full-upgrade -y --no-install-recommends \
-    && apt install -qq -y --no-install-recommends \
+        && apt update -y --no-install-recommends \
+        && apt upgrade -y --no-install-recommends \
+        && apt full-upgrade -y --no-install-recommends \
+        && apt install -qq -y --no-install-recommends \
         build-essential \
         libc-dev \
         libpopt-dev \
@@ -81,13 +87,20 @@ RUN apt install -y \
         libsystemd-dev libsystemd0 liblz4-1
 {{- end }}
 
+{{- if eq .DEBIAN_VERSION "11"}}
+RUN apt update \
+        && apt install -y --allow-downgrades --fix-broken \
+        libsystemd0=247.3-7+deb11u2
+{{- end }}
+
 {{- if or (eq .DEBIAN_VERSION "10") (eq .DEBIAN_VERSION "11") (eq .DEBIAN_VERSION "12")}}
+
 # librpm-dev
-RUN apt install -y \
+RUN apt install -y --install-suggests --fix-broken \
         librpm-dev
 
 # libsystemd-dev
-RUN apt install -y \
+RUN apt install -y --install-suggests --fix-broken \
         libsystemd-dev
 {{- end }}
 
@@ -102,15 +115,15 @@ COPY rootfs /
 
 # Basic test
 RUN cd / \
-  && aarch64-linux-gnu-gcc helloWorld.c -o helloWorld \
-  && file helloWorld \
-  && readelf -h helloWorld \
-  && file helloWorld | cut -d "," -f 2 | grep -c 'ARM aarch64'\
-  && rm helloWorld.c helloWorld
+        && aarch64-linux-gnu-gcc helloWorld.c -o helloWorld \
+        && file helloWorld \
+        && readelf -h helloWorld \
+        && file helloWorld | cut -d "," -f 2 | grep -c 'ARM aarch64'\
+        && rm helloWorld.c helloWorld
 
 RUN cd /libpcap/libpcap-1.8.1 \
-	&& CC=aarch64-linux-gnu-gcc ./configure --enable-usb=no --enable-bluetooth=no --enable-dbus=no --host=aarch64-unknown-linux-gnu --with-pcap=linux \
-	&& make
+        && CC=aarch64-linux-gnu-gcc ./configure --enable-usb=no --enable-bluetooth=no --enable-dbus=no --host=aarch64-unknown-linux-gnu --with-pcap=linux \
+        && make
 
 # Build-time metadata as defined at http://label-schema.org.
 ARG BUILD_DATE
@@ -118,7 +131,7 @@ ARG IMAGE
 ARG VCS_REF
 ARG VCS_URL
 LABEL org.label-schema.build-date=$BUILD_DATE \
-      org.label-schema.name=$IMAGE \
-      org.label-schema.vcs-ref=$VCS_REF \
-      org.label-schema.vcs-url=$VCS_URL \
-      org.label-schema.schema-version="1.0"
+        org.label-schema.name=$IMAGE \
+        org.label-schema.vcs-ref=$VCS_REF \
+        org.label-schema.vcs-url=$VCS_URL \
+        org.label-schema.schema-version="1.0"

--- a/go/arm/Dockerfile.tmpl
+++ b/go/arm/Dockerfile.tmpl
@@ -3,11 +3,6 @@ ARG VERSION
 ARG TAG_EXTENSION=''
 FROM --platform=linux/amd64 ${REPOSITORY}/golang-crossbuild:${VERSION}-base${TAG_EXTENSION} as stage-amd64
 
-# Needed by libsystemd-dev 247.3-7+deb11u4
-{{- if eq .DEBIAN_VERSION "11"}}
-RUN echo "deb http://deb.debian.org/debian bullseye-updates main" >> /etc/apt/sources.list
-{{- end }}
-
 RUN dpkg --add-architecture arm64 \
         && apt update -y --no-install-recommends \
         && apt upgrade -y --no-install-recommends \
@@ -56,11 +51,6 @@ ARG REPOSITORY
 ARG VERSION
 ARG TAG_EXTENSION=''
 FROM --platform=linux/arm64 ${REPOSITORY}/golang-crossbuild:${VERSION}-base${TAG_EXTENSION} as stage-arm64
-
-# Needed by libsystemd-dev 247.3-7+deb11u4
-{{- if eq .DEBIAN_VERSION "11"}}
-RUN echo "deb http://deb.debian.org/debian bullseye-updates main" >> /etc/apt/sources.list
-{{- end }}
 
 RUN dpkg --add-architecture arm64 \
         && apt update -y --no-install-recommends \

--- a/go/arm/Dockerfile.tmpl
+++ b/go/arm/Dockerfile.tmpl
@@ -3,6 +3,11 @@ ARG VERSION
 ARG TAG_EXTENSION=''
 FROM --platform=linux/amd64 ${REPOSITORY}/golang-crossbuild:${VERSION}-base${TAG_EXTENSION} as stage-amd64
 
+# Needed by libsystemd-dev 247.3-7+deb11u4
+{{- if eq .DEBIAN_VERSION "11"}}
+RUN echo "deb http://deb.debian.org/debian bullseye-updates main" >> /etc/apt/sources.list
+{{- end }}
+
 RUN dpkg --add-architecture arm64 \
         && apt update -y --no-install-recommends \
         && apt upgrade -y --no-install-recommends \
@@ -36,19 +41,15 @@ RUN apt install -y \
         libsystemd-dev:arm64 libsystemd0:arm64 liblz4-1:arm64
 {{- end }}
 
-{{- if eq .DEBIAN_VERSION "11"}}
-RUN apt update \
-        && apt install -y \
-        libsystemd0:arm64=247.3-7+deb11u2
-{{- end }}
 
 {{- if or (eq .DEBIAN_VERSION "10") (eq .DEBIAN_VERSION "11") (eq .DEBIAN_VERSION "12")}}
-RUN apt install -y --install-suggests \
+RUN apt install -y \
         librpm-dev:arm64
 
-# libsystemd-dev
+# For Debian 11 libsystemd-dev must be 247.3-7+deb11u4 because of preinstalled libsystemd0:247.3-7+deb11u4 
+# See https://github.com/elastic/golang-crossbuild/pull/316
 RUN apt install -y \
-        libsystemd-dev:arm64
+        libsystemd-dev:arm64{{- if eq .DEBIAN_VERSION "11"}}=247.3-7+deb11u4{{- end }}
 {{- end }}
 
 ARG REPOSITORY
@@ -56,6 +57,10 @@ ARG VERSION
 ARG TAG_EXTENSION=''
 FROM --platform=linux/arm64 ${REPOSITORY}/golang-crossbuild:${VERSION}-base${TAG_EXTENSION} as stage-arm64
 
+# Needed by libsystemd-dev 247.3-7+deb11u4
+{{- if eq .DEBIAN_VERSION "11"}}
+RUN echo "deb http://deb.debian.org/debian bullseye-updates main" >> /etc/apt/sources.list
+{{- end }}
 
 RUN dpkg --add-architecture arm64 \
         && apt update -y --no-install-recommends \
@@ -87,21 +92,16 @@ RUN apt install -y \
         libsystemd-dev libsystemd0 liblz4-1
 {{- end }}
 
-{{- if eq .DEBIAN_VERSION "11"}}
-RUN apt update \
-        && apt install -y --allow-downgrades  \
-        libsystemd0=247.3-7+deb11u2
-{{- end }}
-
 {{- if or (eq .DEBIAN_VERSION "10") (eq .DEBIAN_VERSION "11") (eq .DEBIAN_VERSION "12")}}
 
 # librpm-dev
-RUN apt install -y --install-suggests \
+RUN apt install -y  \
         librpm-dev
 
-# libsystemd-dev
-RUN apt install -y --install-suggests \
-        libsystemd-dev
+# For Debian 11 libsystemd-dev must be 247.3-7+deb11u4 because of preinstalled libsystemd0:247.3-7+deb11u4 
+# See https://github.com/elastic/golang-crossbuild/pull/316
+RUN apt install -y  \
+        libsystemd-dev{{- if eq .DEBIAN_VERSION "11"}}=247.3-7+deb11u4{{- end }}
 {{- end }}
 
 # Declare TARGETARCH to make it available

--- a/go/arm/Dockerfile.tmpl
+++ b/go/arm/Dockerfile.tmpl
@@ -32,12 +32,12 @@ RUN apt install -y \
         libsqlite3-0:arm64
 
 # libsystemd-dev
-RUN apt install -y --fix-broken \
+RUN apt install -y \
         libsystemd-dev:arm64 libsystemd0:arm64 liblz4-1:arm64
 {{- end }}
 
 {{- if eq .DEBIAN_VERSION "11"}}
-RUN apt update --install-suggests --fix-broken \
+RUN apt update \
         && apt install -y \
         libsystemd0:arm64=247.3-7+deb11u2
 {{- end }}
@@ -89,18 +89,18 @@ RUN apt install -y \
 
 {{- if eq .DEBIAN_VERSION "11"}}
 RUN apt update \
-        && apt install -y --allow-downgrades --fix-broken \
+        && apt install -y --allow-downgrades  \
         libsystemd0=247.3-7+deb11u2
 {{- end }}
 
 {{- if or (eq .DEBIAN_VERSION "10") (eq .DEBIAN_VERSION "11") (eq .DEBIAN_VERSION "12")}}
 
 # librpm-dev
-RUN apt install -y --install-suggests --fix-broken \
+RUN apt install -y --install-suggests \
         librpm-dev
 
 # libsystemd-dev
-RUN apt install -y --install-suggests --fix-broken \
+RUN apt install -y --install-suggests \
         libsystemd-dev
 {{- end }}
 

--- a/go/base/sources-debian11.list
+++ b/go/base/sources-debian11.list
@@ -1,3 +1,4 @@
 # see https://wiki.debian.org/CrossToolchains
 deb http://deb.debian.org/debian bullseye main
+deb http://deb.debian.org/debian bullseye-updates main
 deb http://deb.debian.org/debian-security/ bullseye-security main

--- a/go/main/Dockerfile.tmpl
+++ b/go/main/Dockerfile.tmpl
@@ -4,38 +4,44 @@ ARG TAG_EXTENSION=''
 FROM ${REPOSITORY}/golang-crossbuild:${VERSION}-base${TAG_EXTENSION}
 
 RUN \
-    dpkg --add-architecture i386 \
-    && apt-get -o Acquire::Check-Valid-Until=false update \
-    && apt-get install -qq -y --no-install-recommends --allow-unauthenticated \
-        clang \
-        g++ \
-        gcc \
-        gcc-multilib \
-        libc6-dev \
-        libc6-dev-i386 \
-        linux-libc-dev:i386 \
-        mingw-w64 \
-        mingw-w64-tools \
-        patch \
-        xz-utils \
-        unzip
+  dpkg --add-architecture i386 \
+  && apt-get -o Acquire::Check-Valid-Until=false update \
+  && apt-get install -qq -y --no-install-recommends --allow-unauthenticated \
+  clang \
+  g++ \
+  gcc \
+  gcc-multilib \
+  libc6-dev \
+  libc6-dev-i386 \
+  linux-libc-dev:i386 \
+  mingw-w64 \
+  mingw-w64-tools \
+  patch \
+  xz-utils \
+  unzip
 
 {{- if ne .DEBIAN_VERSION "7" }}
 # librpm-dev
 RUN apt install -y --no-install-recommends --allow-unauthenticated\
-        librpm-dev \
-        libxml2-dev \
-        libsqlite3-dev
+  librpm-dev \
+  libxml2-dev \
+  libsqlite3-dev
+
+{{- if eq .DEBIAN_VERSION "11"}}
+RUN apt update \
+  && apt install -y \
+  libsystemd0=247.3-7+deb11u2
+{{- end }}
 
 # libsystemd-dev
-RUN apt install -y --no-install-recommends --allow-unauthenticated\
-         libsystemd-dev
+RUN apt install -y --install-suggests \
+  libsystemd-dev
 {{- end }}
 
 {{- if or (eq .DEBIAN_VERSION "9") (eq .DEBIAN_VERSION "10") (eq .DEBIAN_VERSION "11") (eq .DEBIAN_VERSION "12")}}
 # msitools
 RUN apt install -y --no-install-recommends --allow-unauthenticated\
-         msitools
+  msitools
 {{- end }}
 
 RUN rm -rf /var/lib/apt/lists/*
@@ -54,8 +60,8 @@ RUN cd /libpcap/libpcap-1.8.1 \
   && cp -R /libpcap/libpcap-1.8.1 /libpcap/libpcap-1.8.1-i386 \
   && cp -R /libpcap/libpcap-1.8.1 /libpcap/libpcap-1.8.1-amd64 \
   && cd /libpcap/libpcap-1.8.1-i386 \
-	&& CFLAGS="-m32" LDFLAGS="-m32" ./configure --enable-usb=no --enable-bluetooth=no --enable-dbus=no \
-	&& make \
+  && CFLAGS="-m32" LDFLAGS="-m32" ./configure --enable-usb=no --enable-bluetooth=no --enable-dbus=no \
+  && make \
   && cd /libpcap/libpcap-1.8.1-amd64 \
   && ./configure --enable-usb=no --enable-bluetooth=no --enable-dbus=no \
   && make
@@ -70,11 +76,11 @@ RUN curl -sSLO https://storage.googleapis.com/obs-ci-cache/beats/WpdPack_4_1_2.z
   && echo "0948518b229fb502b9c063966fc3afafbb749241a1c184f6eb7d532e00bce1d8  wpcap.dll" | sha256sum -c - \
   && gendef wpcap.dll \
   && x86_64-w64-mingw32-dlltool \
-    --as-flags=--64 \
-    -m i386:x86-64 \
-    -k \
-    --output-lib /libpcap/win/WpdPack/Lib/x64/libwpcap.a \
-    --input-def /libpcap/win/WpdPack/wpcap.def
+  --as-flags=--64 \
+  -m i386:x86-64 \
+  -k \
+  --output-lib /libpcap/win/WpdPack/Lib/x64/libwpcap.a \
+  --input-def /libpcap/win/WpdPack/wpcap.def
 
 # Build-time metadata as defined at http://label-schema.org.
 ARG BUILD_DATE
@@ -82,7 +88,7 @@ ARG IMAGE
 ARG VCS_REF
 ARG VCS_URL
 LABEL org.label-schema.build-date=$BUILD_DATE \
-      org.label-schema.name=$IMAGE \
-      org.label-schema.vcs-ref=$VCS_REF \
-      org.label-schema.vcs-url=$VCS_URL \
-      org.label-schema.schema-version="1.0"
+  org.label-schema.name=$IMAGE \
+  org.label-schema.vcs-ref=$VCS_REF \
+  org.label-schema.vcs-url=$VCS_URL \
+  org.label-schema.schema-version="1.0"

--- a/go/main/Dockerfile.tmpl
+++ b/go/main/Dockerfile.tmpl
@@ -3,11 +3,6 @@ ARG VERSION
 ARG TAG_EXTENSION=''
 FROM ${REPOSITORY}/golang-crossbuild:${VERSION}-base${TAG_EXTENSION}
 
-# Needed by libsystemd-dev 247.3-7+deb11u4
-{{- if eq .DEBIAN_VERSION "11"}}
-RUN echo "deb http://deb.debian.org/debian bullseye-updates main" >> /etc/apt/sources.list
-{{- end }}
-
 RUN \
   dpkg --add-architecture i386 \
   && apt-get -o Acquire::Check-Valid-Until=false update \

--- a/go/main/Dockerfile.tmpl
+++ b/go/main/Dockerfile.tmpl
@@ -3,6 +3,11 @@ ARG VERSION
 ARG TAG_EXTENSION=''
 FROM ${REPOSITORY}/golang-crossbuild:${VERSION}-base${TAG_EXTENSION}
 
+# Needed by libsystemd-dev 247.3-7+deb11u4
+{{- if eq .DEBIAN_VERSION "11"}}
+RUN echo "deb http://deb.debian.org/debian bullseye-updates main" >> /etc/apt/sources.list
+{{- end }}
+
 RUN \
   dpkg --add-architecture i386 \
   && apt-get -o Acquire::Check-Valid-Until=false update \
@@ -21,21 +26,16 @@ RUN \
   unzip
 
 {{- if ne .DEBIAN_VERSION "7" }}
-# librpm-dev
+# librpm-dev
 RUN apt install -y --no-install-recommends --allow-unauthenticated\
   librpm-dev \
   libxml2-dev \
   libsqlite3-dev
 
-{{- if eq .DEBIAN_VERSION "11"}}
-RUN apt update \
-  && apt install -y --allow-downgrades \
-  libsystemd0=247.3-7+deb11u2
-{{- end }}
-
-# libsystemd-dev
-RUN apt install -y --install-suggests \
-  libsystemd-dev
+# For Debian 11 libsystemd-dev must be 247.3-7+deb11u4 because of preinstalled libsystemd0:247.3-7+deb11u4 
+# See https://github.com/elastic/golang-crossbuild/pull/316
+RUN apt install -y --no-install-recommends --allow-unauthenticated\
+  libsystemd-dev{{- if eq .DEBIAN_VERSION "11" }}=247.3-7+deb11u4{{- end }}
 {{- end }}
 
 {{- if or (eq .DEBIAN_VERSION "9") (eq .DEBIAN_VERSION "10") (eq .DEBIAN_VERSION "11") (eq .DEBIAN_VERSION "12")}}

--- a/go/main/Dockerfile.tmpl
+++ b/go/main/Dockerfile.tmpl
@@ -29,7 +29,7 @@ RUN apt install -y --no-install-recommends --allow-unauthenticated\
 
 {{- if eq .DEBIAN_VERSION "11"}}
 RUN apt update \
-  && apt install -y \
+  && apt install -y --allow-downgrades \
   libsystemd0=247.3-7+deb11u2
 {{- end }}
 


### PR DESCRIPTION
### What happened 
A week ago Debian:11.7 was updated. Now it has preinstalled `libsystemd0:247.3-7+deb11u4`. `libsystemd-dev` requires  `libsystemd0` to be preinstalled and to have exactly same version as with specific version `libsystemd-dev`. 


### Solution
`libsystemd-dev247.3-7+deb11u4` is not yet in the `bullseye` repository and the PR adds `bullseye-updates` to the `sources.list` and now we install the specified `libsystemd-dev247.3-7+deb11u4` for `Debian:11`
