### PR TITLE
docs: how to backport ncap to an existing golang-crossbuild version

### DIFF
--- a/NPCAP.md
+++ b/NPCAP.md
@@ -9,3 +9,26 @@ If you'd like to bump the npcap version please follow the below steps:
   * **NOTE**: This particular Google Bucket can be accessible only by Elasticians who have got access to the Google project called `elastic-observability`.
 
 Credentials to the artifact service can be found in the `APM-Shared` folder in the password management tool.
+
+## Backports
+
+If you'd like to backport any NCAP_VERSION to any existing golang-crosbuild version, then you need to:
+
+* Create a branch called `major.minor.patch.x` for the `vmajor.minor.patch` tag
+* Cherry-pick your PR, you can use `Mergifyio`, with `@mergifyio backport major.minor.path.x`
+* Then the new PR that has been created can be merged when all the GitHub checks have passed.
+
+For instance, if ncap version needs to be updated in `1.20.8` then:
+
+```bash
+git checkout v1.20.8
+git checkout -b 1.20.8.x
+git push upstream 1.20.8.x
+```
+
+Afterwards you can then backport your PR with ncap changes with the GitHub command `@Mergifyio backport 1.20.8.x`,
+see https://github.com/elastic/golang-crossbuild/pull/315 that illustrates this example.
+
+https://github.com/elastic/golang-crossbuild/pull/320 is the one that has been created with the backport targeting
+`1.20.8.x`. Automatically when it gets merged, the golang-crossbuild:1.20.8 will be regenerated and contain the
+new ncap changes.


### PR DESCRIPTION
Trying to explain in the existing docs how the ncap could be backported to an existing golang-crossbuild version.

https://github.com/elastic/golang-crossbuild/pull/315#issuecomment-1723228820 is the one explaining these steps tool.