### PR TITLE
Added pipelines for llvm-apple and fpm

### DIFF
--- a/.buildkite/fpm-pipeline.yml
+++ b/.buildkite/fpm-pipeline.yml
@@ -1,0 +1,3 @@
+steps:
+  - label: "Example test"
+    command: echo "Hello!"

--- a/.buildkite/llvm-apple-pipeline.yml
+++ b/.buildkite/llvm-apple-pipeline.yml
@@ -1,0 +1,3 @@
+steps:
+  - label: "Example test"
+    command: echo "Hello!"

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -58,3 +58,93 @@ spec:
           access_level: MANAGE_BUILD_AND_READ
         everyone:
           access_level: READ_ONLY
+
+---
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: buildkite-pipeline-llvm-apple-version
+  description: "Pipeline for LLVM Apple version"
+  links:
+    - title: Pipeline
+      url: https://buildkite.com/elastic/llvm-apple
+
+spec:
+  type: buildkite-pipeline
+  owner: group:ingest-fp
+  system: buildkite
+  implementation:
+    apiVersion: buildkite.elastic.dev/v1
+    kind: Pipeline
+    metadata:
+      name: llvm-apple
+      description: "Pipeline for LLVM Apple version"
+    spec:
+      #      branch_configuration: "main v1.*" # temporarily disable to build PRs from forks  #TODO - enable when pipeline is ready
+      pipeline_file: ".buildkite/llvm-apple-pipeline.yml"
+      provider_settings:
+        build_tags: true
+        publish_commit_status: true
+        build_pull_request_forks: false
+        build_pull_requests: true # requires filter_enabled and filter_condition settings as below when used with buildkite-pr-bot
+        filter_enabled: true
+        filter_condition: >-
+          build.pull_request.id == null || (build.creator.name == 'elasticmachine' && build.pull_request.id != null)
+      repository: elastic/golang-crossbuild
+      cancel_intermediate_builds: true
+      cancel_intermediate_builds_branch_filter: '!main'
+      skip_intermediate_builds: true
+      skip_intermediate_builds_branch_filter: '!main'
+      #      env:
+      #        ELASTIC_PR_COMMENTS_ENABLED: 'true'  #TODO - enable when pipeline is ready
+      teams:
+        ingest-fp:
+          access_level: MANAGE_BUILD_AND_READ
+        everyone:
+          access_level: READ_ONLY
+
+---
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: buildkite-pipeline-fpm
+  description: "Pipeline for FPM (packaging made simple)"
+  links:
+    - title: Pipeline
+      url: https://buildkite.com/elastic/fpm
+
+spec:
+  type: buildkite-pipeline
+  owner: group:ingest-fp
+  system: buildkite
+  implementation:
+    apiVersion: buildkite.elastic.dev/v1
+    kind: Pipeline
+    metadata:
+      name: fpm
+      description: "Pipeline for FPM (packaging made simple)"
+    spec:
+      #      branch_configuration: "main v1.*" # temporarily disable to build PRs from forks  #TODO - enable when pipeline is ready
+      pipeline_file: ".buildkite/fpm-pipeline.yml"
+      provider_settings:
+        build_tags: true
+        publish_commit_status: true
+        build_pull_request_forks: false
+        build_pull_requests: true # requires filter_enabled and filter_condition settings as below when used with buildkite-pr-bot
+        filter_enabled: true
+        filter_condition: >-
+          build.pull_request.id == null || (build.creator.name == 'elasticmachine' && build.pull_request.id != null)
+      repository: elastic/golang-crossbuild
+      cancel_intermediate_builds: true
+      cancel_intermediate_builds_branch_filter: '!main'
+      skip_intermediate_builds: true
+      skip_intermediate_builds_branch_filter: '!main'
+      #      env:
+      #        ELASTIC_PR_COMMENTS_ENABLED: 'true'  #TODO - enable when pipeline is ready
+      teams:
+        ingest-fp:
+          access_level: MANAGE_BUILD_AND_READ
+        everyone:
+          access_level: READ_ONLY


### PR DESCRIPTION
In scope of [1695](https://github.com/elastic/ingest-dev/issues/1695) added pipelines for "LLVM - apple version" and "FPM - packaging made simple" pipelines