### PR TITLE
Updated pull-requests.json with llvm-apple & fpm pipelines

### DIFF
--- a/.buildkite/pull-requests.json
+++ b/.buildkite/pull-requests.json
@@ -16,6 +16,40 @@
             "skip_ci_on_only_changed": [ ],
             "always_require_ci_on_changed": [ ],
             "fail_on_not_mergeable": true
+        },
+        {
+          "enabled": true,
+          "pipelineSlug": "llvm-apple",
+          "allow_org_users": true,
+          "allowed_repo_permissions": ["admin", "write"],
+          "allowed_list": ["dependabot[bot]", "mergify[bot]"],
+          "set_commit_status": true,
+          "build_on_commit": true,
+          "build_on_comment": true,
+          "trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:build|test)\\W+(?:this|it))|^/test$",
+          "always_trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:build|test)\\W+(?:this|it))|^/test$",
+          "skip_ci_labels": [  ],
+          "skip_target_branches": [ ],
+          "skip_ci_on_only_changed": [ ],
+          "always_require_ci_on_changed": [ ],
+          "fail_on_not_mergeable": true
+        },
+        {
+          "enabled": true,
+          "pipelineSlug": "fpm",
+          "allow_org_users": true,
+          "allowed_repo_permissions": ["admin", "write"],
+          "allowed_list": ["dependabot[bot]", "mergify[bot]"],
+          "set_commit_status": true,
+          "build_on_commit": true,
+          "build_on_comment": true,
+          "trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:build|test)\\W+(?:this|it))|^/test$",
+          "always_trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:build|test)\\W+(?:this|it))|^/test$",
+          "skip_ci_labels": [  ],
+          "skip_target_branches": [ ],
+          "skip_ci_on_only_changed": [ ],
+          "always_require_ci_on_changed": [ ],
+          "fail_on_not_mergeable": true
         }
     ]
 }


### PR DESCRIPTION
In scope of [1695](https://github.com/elastic/ingest-dev/issues/1695) added llvm-apple and fpm pipelines to execute in Buildkite