### PR TITLE
bk: post-release should not fail

### DIFF
--- a/.buildkite/scripts/post-release.sh
+++ b/.buildkite/scripts/post-release.sh
@@ -23,10 +23,14 @@ git_push_with_auth() {
 }
 
 if [[ "${TAG_EXISTS}" == true ]]; then
-  echo "Tag already exists! Exiting Post-release stage."
-  exit 1
+  message="Tag '$TAG' already exists! Exiting Post-release stage."
+  echo "$message"
+  buildkite-agent annotate "$message" --style 'warning' --context 'ctx-warn'
+  # This should return any error but skip the release.
+  exit 0
 fi
 
 set_git_config
 tag_commit
 git_push_with_auth
+buildkite-agent annotate "Tag '$TAG' has been created." --style 'success' --context 'ctx-success'


### PR DESCRIPTION
Rather than failing the build let's do nothing and report with a [buildkite annotation](https://buildkite.com/docs/agent/v3/cli-annotate)


Probably this could be split into two actions:
1) If a tag exists then do nothing and report a new github check saying exists
2) If a tag does not exist  and report a new github check saying it has been created.


But 