### PR TITLE
docs: explain how to update the auto-bump

### DIFF
--- a/.github/workflows/bump-golang-previous.yml
+++ b/.github/workflows/bump-golang-previous.yml
@@ -1,5 +1,5 @@
 ---
-name: bump-golang-1.20
+name: bump-golang-previous
 
 on:
   workflow_dispatch:
@@ -16,7 +16,9 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./.github/workflows/bump-golang
         with:
+          # NOTE: when a new golang version please update me with 1.<go-version-1>
           branch: '1.20'
+          # NOTE: when a new golang version please update me with 1.<go-version-1>
           go-minor: '1.20'
           vaultUrl: ${{ secrets.VAULT_ADDR }}
           vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}

--- a/.github/workflows/bump-golang.yml
+++ b/.github/workflows/bump-golang.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: ./.github/workflows/bump-golang
         with:
           branch: 'main'
+          # NOTE: when a new golang version please update me with 1.<go-version>
           go-minor: '1.21'
           vaultUrl: ${{ secrets.VAULT_ADDR }}
           vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}

--- a/.github/workflows/opentelemetry.yml
+++ b/.github/workflows/opentelemetry.yml
@@ -5,7 +5,7 @@ on:
   workflow_run:
     workflows:
       - bump-golang-main
-      - bump-golang-1.20
+      - bump-golang-previous
     types: [completed]
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -214,18 +214,15 @@ stateDiagram-v2
 
 ## Releasing images for a new Go version
 
-With every new version of `go` we made a new branch with the name of the previous version to allow us to continue building the Docker images for the previous version of `go`. So if we are in go `1.19` and go `1.20` is released, we create a new branch `1.19`, then we update the `main` branch to install go `1.20` as explained in the below steps: 
+With every new version of `go` we made a new branch with the name of the previous version to allow us to continue building the Docker images for the previous version of `go`. So if we are in go `1.21` and go `1.22` is released, we create a new branch `1.21`, then we update the `main` branch to install go `1.22` as explained in the below steps: 
 
+1. Update the Go version in [.go-version](https://github.com/elastic/golang-crossbuild/blob/main/.go-version).
 1. Update the Docker tag in
-   [Makefile.common](https://github.com/elastic/golang-crossbuild/blob/main/go1.10/Makefile.common#L5) and/or
-   [Makefile.common](https://github.com/elastic/golang-crossbuild/blob/main/go1.11/Makefile.common#L5) and/or
-   [Makefile.common](https://github.com/elastic/golang-crossbuild/blob/main/go1.12/Makefile.common#L5).
-1. Update the Go version and SHA256 in the
-   [Dockerfile(s)](https://github.com/elastic/golang-crossbuild/blob/main/go1.10/base/Dockerfile#L19-L21).
-   The SHA256 must be obtained from <https://golang.org/dl/.>
+   [Makefile.common](https://github.com/elastic/golang-crossbuild/blob/main/go/Makefile.common#L5).
+1. Run `.buildkite/bump-go-release-version.sh "$(cat .go-version)"`
 1. Update the versions listed in this README.md.
-1. Update the `go-minor` value in [bump-golang.yml](https://github.com/elastic/golang-crossbuild/blob/main/github/workflows/bump-golang.yml) with the new minor go version, i.e: `1.20`.
-1. Update the `go-minor` and `branch` values in [bump-golang-previous.yml](https://github.com/elastic/golang-crossbuild/blob/main/github/workflows/bump-golang-previous.yml) with the old minor go version, i.e: `1.19`.
+1. Update the `go-minor` value in [bump-golang.yml](https://github.com/elastic/golang-crossbuild/blob/main/github/workflows/bump-golang.yml) with the new minor go version, i.e: `1.22`.
+1. Update the `go-minor` and `branch` values in [bump-golang-previous.yml](https://github.com/elastic/golang-crossbuild/blob/main/github/workflows/bump-golang-previous.yml) with the old minor go version, i.e: `1.21`.
 1. Commit the changes. `git add -u && git commit -m 'Update to Go 1.x.y'`.
 1. Create a Pull Request with the description `'Update to Go 1.x.y'`.
 1. When merging the PR, the automation will release those docker images.

--- a/README.md
+++ b/README.md
@@ -224,8 +224,8 @@ With every new version of `go` we made a new branch with the name of the previou
    [Dockerfile(s)](https://github.com/elastic/golang-crossbuild/blob/main/go1.10/base/Dockerfile#L19-L21).
    The SHA256 must be obtained from <https://golang.org/dl/.>
 1. Update the versions listed in this README.md.
-1. Update the `go-minor` value in [bump-golang.yml](https://github.com/elastic/golang-crossbuild/blob/main/github/workflows/bump-golang.yml) with the new minor go version, i.e: `1.20`
-1. Update the `go-minor` value in [bump-golang-previous.yml](https://github.com/elastic/golang-crossbuild/blob/main/github/workflows/bump-golang-1.20.yml) with the old minor go version, i.e: `1.19`
+1. Update the `go-minor` value in [bump-golang.yml](https://github.com/elastic/golang-crossbuild/blob/main/github/workflows/bump-golang.yml) with the new minor go version, i.e: `1.20`.
+1. Update the `go-minor` and `branch` values in [bump-golang-previous.yml](https://github.com/elastic/golang-crossbuild/blob/main/github/workflows/bump-golang-previous.yml) with the old minor go version, i.e: `1.19`.
 1. Commit the changes. `git add -u && git commit -m 'Update to Go 1.x.y'`.
 1. Create a Pull Request with the description `'Update to Go 1.x.y'`.
 1. When merging the PR, the automation will release those docker images.

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ stateDiagram-v2
 
 ## Releasing images for a new Go version
 
-With every new version of `go` we made a new branch with the name of the previous version to allow continue building the Docker images for the previous version of `go`. So if we are in go `1.19` and go `1.20` is released, we create a new branch `1.19`, the we update the `main` branch to install go `1.20`. Due to the changes in the Debian packages repositories, there is no guaranties that the Docker images for the previous version of `go` will continue to work after some time.
+With every new version of `go` we made a new branch with the name of the previous version to allow us to continue building the Docker images for the previous version of `go`. So if we are in go `1.19` and go `1.20` is released, we create a new branch `1.19`, then we update the `main` branch to install go `1.20` as explained in the below steps: 
 
 1. Update the Docker tag in
    [Makefile.common](https://github.com/elastic/golang-crossbuild/blob/main/go1.10/Makefile.common#L5) and/or
@@ -224,9 +224,13 @@ With every new version of `go` we made a new branch with the name of the previou
    [Dockerfile(s)](https://github.com/elastic/golang-crossbuild/blob/main/go1.10/base/Dockerfile#L19-L21).
    The SHA256 must be obtained from <https://golang.org/dl/.>
 1. Update the versions listed in this README.md.
+1. Update the `go-minor` value in [bump-golang.yml](https://github.com/elastic/golang-crossbuild/blob/main/github/workflows/bump-golang.yml) with the new minor go version, i.e: `1.20`
+1. Update the `go-minor` value in [bump-golang-previous.yml](https://github.com/elastic/golang-crossbuild/blob/main/github/workflows/bump-golang-1.20.yml) with the old minor go version, i.e: `1.19`
 1. Commit the changes. `git add -u && git commit -m 'Update to Go 1.x.y'`.
 1. Create a Pull Request with the description `'Update to Go 1.x.y'`.
-1. When merging the PR then the automation will release those docker images.
+1. When merging the PR, the automation will release those docker images.
+
+**NOTE**: Due to the changes in the Debian packages repositories, there are no guarantees that the Docker images for the previous version of `go` will continue to work after some time.
 
 ## Packaging MacOS SDK
 


### PR DESCRIPTION
This should help with explaining how to update the auto-bump automation, implemented in https://github.com/elastic/golang-crossbuild/pull/262,  when a new Golang version is released.

### Further details

`1.20` was created with https://github.com/elastic/golang-crossbuild/pull/310