### PR TITLE
Change GCS bucket from obs-ci-cache to ingest-buildkite-ci

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -7,7 +7,7 @@ NPCAP_VERSION := 1.79
 NPCAP_FILE    := npcap-$(NPCAP_VERSION)-oem.exe
 SUFFIX_NPCAP_VERSION := -npcap-$(NPCAP_VERSION)
 NPCAP_REPOSITORY := docker.elastic.co/observability-ci
-GS_BUCKET_PATH ?= obs-ci-cache
+GS_BUCKET_PATH ?= ingest-buildkite-ci
 
 
 ifeq ($(BUILDX),1)

--- a/NPCAP.md
+++ b/NPCAP.md
@@ -5,8 +5,8 @@ If you'd like to bump the npcap version please follow the below steps:
 1) Update `NPCAP_VERSION` value in the `Makefile`.
   * **NOTE**: Make sure the PR adding this is back-ported to the Go versions required by the Packetbeat CrossBuild target in [the mage file](https://github.com/elastic/beats/blob/main/x-pack/packetbeat/magefile.go). This is specified in the beats `.go-version` file.
 2) Download the new artifact.
-3) Upload the artifact to `gs://obs-ci-cache/private`.
-  * **NOTE**: This particular Google Bucket can be accessible only by Elasticians who have got access to the Google project called `elastic-observability`.
+3) Upload the artifact to `gs://ingest-buildkite-ci/private`.
+  * **NOTE**: This particular Google Bucket can be accessible only by Elasticians who have got access to the Google project called `elastic-platform-ingest`.
 
 Credentials to the artifact service can be found in the `APM-Shared` folder in the password management tool.
 


### PR DESCRIPTION
Modify the documentation and Makefile.common to reflect the GCS bucket name that CI will be depending upon to hold the npcap installer exe.

Relates #381