### PR TITLE
Make npcap image build fail if installer is not present

### DIFF
--- a/go/Makefile.common
+++ b/go/Makefile.common
@@ -7,7 +7,7 @@ DEBIAN_VERSION ?= 9
 SUFFIX         := -$(shell basename $(CURDIR))
 TAG_EXTENSION  ?=
 
-export DEBIAN_VERSION TAG_EXTENSION
+export DEBIAN_VERSION TAG_EXTENSION NPCAP_FILE
 
 DOCKER_CMD := docker build
 

--- a/go/npcap/Dockerfile.tmpl
+++ b/go/npcap/Dockerfile.tmpl
@@ -3,7 +3,7 @@ ARG VERSION
 ARG TAG_EXTENSION=''
 FROM ${REPOSITORY}/golang-crossbuild:${VERSION}-main${TAG_EXTENSION}
 
-COPY lib /installer
+COPY lib/{{.NPCAP_FILE}} /installer/
 
 # Build-time metadata as defined at http://label-schema.org.
 ARG BUILD_DATE


### PR DESCRIPTION
Make the Dockerfile COPY command fail when the npcap-oem.exe file is not present. This will prevent the npcap image variant from being released without it containing the installer.

Relates #381