### PR TITLE
[CI] Abort image building process if the npcap file non found

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -18,11 +18,11 @@ endif
 
 # Requires login at google storage.
 copy-npcap:
-	ifeq ($(CI),true)
-		@gsutil cp gs://$(GS_BUCKET_PATH)/private/$(NPCAP_FILE) ../npcap/lib/$(NPCAP_FILE) 
-	else
-		@echo 'Only available if running in the CI'
-	endif
+ifeq ($(CI),true)
+	@gsutil cp gs://$(GS_BUCKET_PATH)/private/$(NPCAP_FILE) ../npcap/lib/$(NPCAP_FILE) 
+else
+	@echo 'Only available if running in the CI'
+endif
 
 push:
 	$(MAKE) atomic-push

--- a/Makefile.common
+++ b/Makefile.common
@@ -17,14 +17,12 @@ endif
 endif
 
 # Requires login at google storage.
-copy-npcap: status=".status.copy-npcap"
 copy-npcap:
-	@echo '0' > ${status}
-ifeq ($(CI),true)
-	@gsutil cp gs://$(GS_BUCKET_PATH)/private/$(NPCAP_FILE) ../npcap/lib/$(NPCAP_FILE) || echo '1' > ${status}
-else
-	@echo 'Only available if running in the CI'
-endif
+	ifeq ($(CI),true)
+		@gsutil cp gs://$(GS_BUCKET_PATH)/private/$(NPCAP_FILE) ../npcap/lib/$(NPCAP_FILE) 
+	else
+		@echo 'Only available if running in the CI'
+	endif
 
 push:
 	$(MAKE) atomic-push


### PR DESCRIPTION
`1.79` release caused a problem: the `npcap-1.79.exe` was missing and broken images were published despite of that. 
Now it will stop building process if the required file is missing.
