### PR TITLE
Disable VCS stamping

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -7,6 +7,7 @@ env:
   DOCKER_REGISTRY: "docker.elastic.co"
   STAGING_IMAGE: "${DOCKER_REGISTRY}/observability-ci"
   BUILDX: 1
+  GOFLAGS: "-buildvcs=false"
 
 steps:
   - group: "Staging"

--- a/go/base-arm/rootfs/entrypoint.go
+++ b/go/base-arm/rootfs/entrypoint.go
@@ -105,6 +105,7 @@ func buildEnvironment(platform string) (map[string]string, error) {
 		"GOARCH":      goarch,
 		"GOARM":       goarm,
 		"PLATFORM_ID": platformID,
+		"GOFLAGS": "-buildvcs=false",
 	}
 
 	if err := loadCompilerSettings(goos, arch, env); err != nil {


### PR DESCRIPTION
While migrating beats repo faced an [error](https://buildkite.com/elastic/filebeat/builds/3355#018df489-70c7-4264-b0dc-c5ac70df3e1d/173-184) during packaging.
To fix issue it's required to [disable vcs stamping](https://github.com/microsoft/azurelinux/issues/3273).
