### PR TITLE
github-actions: use github secrets for updatecli

### DIFF
--- a/.github/actions/bump-golang/action.yml
+++ b/.github/actions/bump-golang/action.yml
@@ -42,6 +42,7 @@ runs:
           BRANCH: ${{ inputs.branch }}
           GO_MINOR: ${{ inputs.go-minor }}
           GITHUB_TOKEN: ${{ inputs.github-token }}
+          GIT_USER: "github-actions[bot]"
         shell: bash
 
       - if: ${{ failure()  }}

--- a/.github/actions/bump-golang/action.yml
+++ b/.github/actions/bump-golang/action.yml
@@ -42,6 +42,7 @@ runs:
           BRANCH: ${{ inputs.branch }}
           GO_MINOR: ${{ inputs.go-minor }}
           GITHUB_TOKEN: ${{ inputs.github-token }}
+        shell: bash
 
       - if: ${{ failure()  }}
         uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e # v1.26.0

--- a/.github/actions/bump-golang/action.yml
+++ b/.github/actions/bump-golang/action.yml
@@ -7,28 +7,24 @@ inputs:
   go-minor:
     description: 'What Go minor version ([0-9]+.[0.9]+)'
     required: true
-  messageIfFailure:
-    description: 'Vault secret ID'
-    required: false
-    default: ":traffic_cone: updatecli failed for `${{ github.repository }}@${{ github.ref_name }}`, @agent-team please look what's going on <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>"
-  notifySlackChannel:
-    description: 'Vault secret ID'
-    required: false
-    default: "#ingest-notifications"
-  vaultUrl:
-    description: 'Vault URL'
-    required: true
-  vaultRoleId:
-    description: 'Vault role ID'
-    required: true
-  vaultSecretId:
-    description: 'Vault secret ID'
-    required: true
   command:
     description: 'What updatecli command'
     default: 'apply'
     required: false
-
+  slack-message:
+    description: 'Slack message if failure'
+    required: false
+    default: ":traffic_cone: updatecli failed for `${{ github.repository }}@${{ github.ref_name }}`, @agent-team please look what's going on <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>"
+  slack-channel-id:
+    description: 'Slack channel ID'
+    required: false
+    default: "#ingest-notifications"
+  slack-bot-token:
+    description: 'Specify the slack bot token.'
+    required: true
+  github-token:
+    description: "The GitHub access token."
+    required: true
 runs:
   using: "composite"
   steps:
@@ -36,15 +32,34 @@ runs:
         with:
           ref: ${{ inputs.branch }}
 
-      - uses: elastic/apm-pipeline-library/.github/actions/updatecli@current
-        with:
-          vaultUrl: ${{ inputs.vaultUrl }}
-          vaultRoleId: ${{ inputs.vaultRoleId }}
-          vaultSecretId: ${{ inputs.vaultSecretId }}
-          command: ${{ inputs.command }}
-          pipeline: ./.github/updatecli.d/bump-golang.yml
-          notifySlackChannel: ${{ inputs.notifySlackChannel }}
-          messageIfFailure: ${{ inputs.messageIfFailure }}
+      - name: Install Updatecli in the runner
+        uses: updatecli/updatecli-action@9a37c7e35598d7b37d8e7568b40ed9538112be01 # v0.76.1
+
+      - name: Run Updatecli in Apply mode
+        run: updatecli ${{ env.COMMAND }} --config ./.github/updatecli.d/bump-golang.yml
         env:
+          COMMAND: ${{ inputs.command }}
           BRANCH: ${{ inputs.branch }}
           GO_MINOR: ${{ inputs.go-minor }}
+          GITHUB_TOKEN: ${{ inputs.github-token }}
+
+      - if: ${{ failure()  }}
+        uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e # v1.26.0
+        with:
+          channel-id: ${{ inputs.slack-channel-id }}
+          payload: |
+            {
+              "text": "${{ env.SLACK_MESSAGE }}",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "${{ env.SLACK_MESSAGE }}"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_BOT_TOKEN: ${{ inputs.slack-bot-token }}
+          SLACK_MESSAGE: ${{ inputs.slack-message }}

--- a/.github/workflows/bump-golang-previous.yml
+++ b/.github/workflows/bump-golang-previous.yml
@@ -12,6 +12,9 @@ permissions:
 jobs:
   bump:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/bump-golang
@@ -20,7 +23,6 @@ jobs:
           branch: '1.21'
           # NOTE: when a new golang version please update me with 1.<go-version-1>
           go-minor: '1.21'
-          vaultUrl: ${{ secrets.VAULT_ADDR }}
-          vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
-          vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
           command: '--experimental apply'
+          slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/bump-golang.yml
+++ b/.github/workflows/bump-golang.yml
@@ -12,6 +12,9 @@ permissions:
 jobs:
   bump:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/bump-golang
@@ -19,7 +22,6 @@ jobs:
           branch: 'main'
           # NOTE: when a new golang version please update me with 1.<go-version>
           go-minor: '1.22'
-          vaultUrl: ${{ secrets.VAULT_ADDR }}
-          vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
-          vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
           command: '--experimental apply'
+          slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Use GitHub secrets and remove the need to use the `elastic/apm-pipeline-library` in conjunction with the VAULT_ADDR.

This will help reducing the need of accessing vault but using the GitHub secrets for the slack bot notifications.

Since this project uses Buildkite, we can commit/push using the github-bot actor.

I tested this branch in https://github.com/elastic/golang-crossbuild/actions/runs/9180918975/job/25246450161 and it worked fine