### PR TITLE
Revert "build(deps): bump updatecli/updatecli-action from 2.64.0 to 2.65.0 in /.github/actions/bump-golang in the github-actions group"

### DIFF
--- a/.github/actions/bump-golang/action.yml
+++ b/.github/actions/bump-golang/action.yml
@@ -33,7 +33,7 @@ runs:
           ref: ${{ inputs.branch }}
 
       - name: Install Updatecli in the runner
-        uses: updatecli/updatecli-action@3a8785d88ec4fa03d86521a181f37c0e74627463 # v0.76.1
+        uses: updatecli/updatecli-action@3a8785d88ec4fa03d86521a181f37c0e74627463 # v2.64.0
 
       - name: Run Updatecli in Apply mode
         run: updatecli ${{ env.COMMAND }} --config ./.github/updatecli.d/bump-golang.yml

--- a/.github/actions/bump-golang/action.yml
+++ b/.github/actions/bump-golang/action.yml
@@ -33,7 +33,7 @@ runs:
           ref: ${{ inputs.branch }}
 
       - name: Install Updatecli in the runner
-        uses: updatecli/updatecli-action@a0c478c868a71d3e239a65714de69450aa1ee2c6 # v0.76.1
+        uses: updatecli/updatecli-action@3a8785d88ec4fa03d86521a181f37c0e74627463 # v0.76.1
 
       - name: Run Updatecli in Apply mode
         run: updatecli ${{ env.COMMAND }} --config ./.github/updatecli.d/bump-golang.yml


### PR DESCRIPTION
Reverts elastic/golang-crossbuild#427

Latest updatecli version bump causes issues (probably related to what's described in https://github.com/updatecli/updatecli/pull/2388).
This commit reverts to an older version of updatecli-action as done in other repos e.g. https://github.com/elastic/elastic-package/pull/2005