### PR TITLE
updatecli: set username

### DIFF
--- a/.github/actions/bump-golang/action.yml
+++ b/.github/actions/bump-golang/action.yml
@@ -36,7 +36,7 @@ runs:
         uses: updatecli/updatecli-action@3a8785d88ec4fa03d86521a181f37c0e74627463 # v2.64.0
 
       - name: Run Updatecli in Apply mode
-        run: updatecli ${{ env.COMMAND }} --config ./.github/updatecli.d/bump-golang.yml --debug
+        run: updatecli ${{ env.COMMAND }} --config ./.github/updatecli.d/bump-golang.yml
         env:
           COMMAND: ${{ inputs.command }}
           BRANCH: ${{ inputs.branch }}

--- a/.github/actions/bump-golang/action.yml
+++ b/.github/actions/bump-golang/action.yml
@@ -18,7 +18,7 @@ inputs:
   slack-channel-id:
     description: 'Slack channel ID'
     required: false
-    default: "#ingest-notifications"
+    default: "#on-week-oblt-productivity"
   slack-bot-token:
     description: 'Specify the slack bot token.'
     required: true

--- a/.github/actions/bump-golang/action.yml
+++ b/.github/actions/bump-golang/action.yml
@@ -18,7 +18,7 @@ inputs:
   slack-channel-id:
     description: 'Slack channel ID'
     required: false
-    default: "#on-week-oblt-productivity"
+    default: "#ingest-notifications"
   slack-bot-token:
     description: 'Specify the slack bot token.'
     required: true

--- a/.github/actions/bump-golang/action.yml
+++ b/.github/actions/bump-golang/action.yml
@@ -36,13 +36,12 @@ runs:
         uses: updatecli/updatecli-action@3a8785d88ec4fa03d86521a181f37c0e74627463 # v2.64.0
 
       - name: Run Updatecli in Apply mode
-        run: updatecli ${{ env.COMMAND }} --config ./.github/updatecli.d/bump-golang.yml
+        run: updatecli ${{ env.COMMAND }} --config ./.github/updatecli.d/bump-golang.yml --debug
         env:
           COMMAND: ${{ inputs.command }}
           BRANCH: ${{ inputs.branch }}
           GO_MINOR: ${{ inputs.go-minor }}
           GITHUB_TOKEN: ${{ inputs.github-token }}
-          GIT_USER: "github-actions[bot]"
         shell: bash
 
       - if: ${{ failure()  }}

--- a/.github/updatecli.d/bump-golang.yml
+++ b/.github/updatecli.d/bump-golang.yml
@@ -49,7 +49,7 @@ sources:
       owner: golang
       repository: go
       token: '{{ requiredEnv "GITHUB_TOKEN" }}'
-      username: '{{ requiredEnv "GIT_USER" }}'
+      username: '{{ requiredEnv "GITHUB_ACTOR" }}'
       versionfilter:
         kind: regex
         pattern: go1\.{{ source "minor" }}(\.(\d*))?$

--- a/.github/updatecli.d/bump-golang.yml
+++ b/.github/updatecli.d/bump-golang.yml
@@ -7,6 +7,7 @@ scms:
     kind: github
     spec:
       user: '{{ requiredEnv "GITHUB_ACTOR" }}'
+      username: '{{ requiredEnv "GITHUB_ACTOR" }}'
       owner: v1v
       repository: golang-crossbuild
       token: '{{ requiredEnv "GITHUB_TOKEN" }}'

--- a/.github/updatecli.d/bump-golang.yml
+++ b/.github/updatecli.d/bump-golang.yml
@@ -7,7 +7,7 @@ scms:
     kind: github
     spec:
       user: '{{ requiredEnv "GITHUB_ACTOR" }}'
-      owner: elastic
+      owner: v1v
       repository: golang-crossbuild
       token: '{{ requiredEnv "GITHUB_TOKEN" }}'
       branch: '{{ requiredEnv "BRANCH" }}'

--- a/.github/updatecli.d/bump-golang.yml
+++ b/.github/updatecli.d/bump-golang.yml
@@ -8,7 +8,7 @@ scms:
     spec:
       user: '{{ requiredEnv "GITHUB_ACTOR" }}'
       username: '{{ requiredEnv "GITHUB_ACTOR" }}'
-      owner: v1v
+      owner: elastic
       repository: golang-crossbuild
       token: '{{ requiredEnv "GITHUB_TOKEN" }}'
       branch: '{{ requiredEnv "BRANCH" }}'

--- a/.github/workflows/bump-golang.yml
+++ b/.github/workflows/bump-golang.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/bump-golang
         with:
-          branch: 'test/bump'
+          branch: 'main'
           # NOTE: when a new golang version please update me with 1.<go-version>
           go-minor: '1.22'
           command: '--experimental apply'

--- a/.github/workflows/bump-golang.yml
+++ b/.github/workflows/bump-golang.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/bump-golang
         with:
-          branch: 'main'
+          branch: 'test/bump'
           # NOTE: when a new golang version please update me with 1.<go-version>
           go-minor: '1.22'
           command: '--experimental apply'


### PR DESCRIPTION
For some reason something is not right anymore


```
⚠ - 1 file(s) updated with "1.22.6":
	* go/Makefile.common
ERROR: non-fast-forward update
ERROR: push error: authentication required
```

I saw we could pass the username when interacting with [github](https://www.updatecli.io/docs/plugins/scm/github/)

<img width="1308" alt="image" src="https://github.com/user-attachments/assets/5e632801-3221-4ed0-a5f9-89447f741bb6">


And this solved the issue, see https://github.com/v1v/golang-crossbuild/pull/1 that verified the changes for this PR.

Maybe something has changed in the GitHub API internals?