### PR TITLE
ci: support previous minor 1.22

### DIFF
--- a/.github/workflows/bump-golang-previous.yml
+++ b/.github/workflows/bump-golang-previous.yml
@@ -20,9 +20,9 @@ jobs:
       - uses: ./.github/actions/bump-golang
         with:
           # NOTE: when a new golang version please update me with 1.<go-version-1>
-          branch: '1.21'
+          branch: '1.22'
           # NOTE: when a new golang version please update me with 1.<go-version-1>
-          go-minor: '1.21'
+          go-minor: '1.22'
           command: '--experimental apply'
           slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Since `1.22` was transitioned to a maintenance branch from `main`, `main` is now pointing to `1.23`. This is required 

A leftover from https://github.com/elastic/golang-crossbuild/pull/436