### PR TITLE
mergify: replace queue action for queue_rules

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,5 +1,6 @@
 queue_rules:
   - name: default
+    merge_method: squash
     conditions:
       - check-success=buildkite/golang-crossbuild
       - check-success=CLA
@@ -51,7 +52,6 @@ pull_request_rules:
       - files~=^go/Makefile.common
     actions:
       queue:
-        method: squash
         name: default
   - name: notify the backport has not been merged yet
     conditions:


### PR DESCRIPTION
## Details

⚠️ This PR was created by an automated tool. Please review the changes carefully. ⚠️ 

Use queue_rules instead of queue action

## Why

The queue action from workflow automation has deprecated all of its configuration options

https://changelog.mergify.com/changelog/queue-action-options-deprecation
