### PR TITLE
Fix: remove support for debian 11 on armel, mips, ppc and s390x

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -39,7 +39,6 @@ template: |
   - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-arm-debian11` - linux/armv5, linux/armv6
   - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-arm-debian12` - linux/armv5, linux/armv6
   - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-armel` - linux/armv5, linux/armv6
-  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-armel-debian9` - linux/armv5, linux/armv6
   - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-armel-debian12` - linux/armv5, linux/armv6
   - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-armhf` - linux/armv7
   - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-armhf-debian9` - linux/armv7

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -40,7 +40,6 @@ template: |
   - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-arm-debian12` - linux/armv5, linux/armv6
   - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-armel` - linux/armv5, linux/armv6
   - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-armel-debian9` - linux/armv5, linux/armv6
-  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-armel-debian11` - linux/armv5, linux/armv6
   - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-armel-debian12` - linux/armv5, linux/armv6
   - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-armhf` - linux/armv7
   - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-armhf-debian9` - linux/armv7
@@ -56,11 +55,8 @@ template: |
   - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-main-debian10` - linux/i386, linux/amd64, windows/amd64
   - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-main-debian11` - linux/i386, linux/amd64, windows/amd64
   - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-main-debian12` - linux/i386, linux/amd64, windows/amd64
-  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-mips-debian11` - linux/mips64, linux/mips64el
   - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-mips-debian12` - linux/mips64, linux/mips64el
-  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-ppc-debian11` - linux/ppc64, linux/ppc64le
   - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-ppc-debian12` - linux/ppc64, linux/ppc64le
-  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-s390x-debian11` - linux/s390x
   - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-s390x-debian12` - linux/s390x
 
   ### Changes

--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ It is used to cross compile for `linux/arm64`. This Docker image is based on the
 
 ## go/armel Docker image
 
-The `armel` image is the base image for the `armel` architecture, it is build for Debian 9+.
+The `armel` image is the base image for the `armel` architecture, it is build for Debian 12+.
 It is used to cross compile for `linux/armel`. This Docker image is based on the `base` image.
 
 ## go/armhf Docker image

--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ It is used to cross compile for `linux/armhf`. This Docker image is based on the
 
 ## go/mips Docker image
 
-The `mips` image is the base image for the `mips` architecture, it is build for Debian 11+.
+The `mips` image is the base image for the `mips` architecture, it is build for Debian 12+.
 It is used to cross compile for `linux/mips`. This Docker image is based on the `base` image.
 
 ## go/mips32 Docker image
@@ -337,12 +337,12 @@ It is used to cross compile for `linux/mips32`. This Docker image is based on th
 
 ## go/ppc Docker image
 
-The `ppc` image is the base image for the `ppc` architecture, it is build for Debian 11+.
+The `ppc` image is the base image for the `ppc` architecture, it is build for Debian 12+.
 It is used to cross compile for `linux/ppc`. This Docker image is based on the `base` image.
 
 ## go/s390x Docker image
 
-The `s390x` image is the base image for the `s390x` architecture, it is build for Debian 11+.
+The `s390x` image is the base image for the `s390x` architecture, it is build for Debian 12+.
 It is used to cross compile for `linux/s390x`. This Docker image is based on the `base` image.
 
 ## go/npcap Docker image

--- a/go/Makefile.debian11
+++ b/go/Makefile.debian11
@@ -1,4 +1,4 @@
-IMAGES         := base main darwin arm armhf armel mips ppc s390x darwin-arm64 npcap
+IMAGES         := base main darwin arm armhf darwin-arm64 npcap
 DEBIAN_VERSION := 11
 TAG_EXTENSION  := -debian11
 

--- a/go/Makefile.debian9
+++ b/go/Makefile.debian9
@@ -1,4 +1,4 @@
-IMAGES         := base main darwin arm armhf armel npcap
+IMAGES         := base main darwin arm armhf npcap
 ARM_IMAGES     := base-arm
 DEBIAN_VERSION := 9
 TAG_EXTENSION  := -debian9


### PR DESCRIPTION
### What

Remove support for `Debian 10` on `armel`, `mips`, `ppc` and `s390x`. Recent changes on the `libsystem-dev` package in `Debian 11` have broken the way we install this library, due to we have support on `Debian 12` that works fine for those architectures we remove support for them on `Debian 11`.

### Issues

Similar to https://github.com/elastic/golang-crossbuild/pull/175
Similar to https://github.com/elastic/golang-crossbuild/pull/225
Closes https://github.com/elastic/golang-crossbuild/issues/444 