### PR TITLE
Update npcap to 1.80

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -3,7 +3,7 @@ VCS_REF       := $(shell git rev-parse HEAD)
 VCS_URL       := https://github.com/elastic/golang-crossbuild
 BUILD_DATE    := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 .DEFAULT_GOAL := build
-NPCAP_VERSION := 1.79
+NPCAP_VERSION := 1.80
 NPCAP_FILE    := npcap-$(NPCAP_VERSION)-oem.exe
 SUFFIX_NPCAP_VERSION := -npcap-$(NPCAP_VERSION)
 NPCAP_REPOSITORY := docker.elastic.co/observability-ci
@@ -19,7 +19,7 @@ endif
 # Requires login at google storage.
 copy-npcap:
 ifeq ($(CI),true)
-	@gsutil cp gs://$(GS_BUCKET_PATH)/private/$(NPCAP_FILE) ../npcap/lib/$(NPCAP_FILE) 
+	@gsutil cp gs://$(GS_BUCKET_PATH)/private/$(NPCAP_FILE) ../npcap/lib/$(NPCAP_FILE)
 else
 	@echo 'Only available if running in the CI'
 endif


### PR DESCRIPTION
Updates npcap to version 1.80. I'm reading [the docs](https://github.com/elastic/golang-crossbuild/blob/ece4a5a9405975712dd2df2ee2e18e11c6c728f2/NPCAP.md) about updating npcap, and I don't quite get this comment:

> Make sure the PR adding this is back-ported to the Go versions required by the Packetbeat CrossBuild target in [the mage file](https://github.com/elastic/beats/blob/main/x-pack/packetbeat/magefile.go)


Is the go version in `.go-version`. linked to `golang-crossbuild` in some way?