### PR TITLE
Update NPCAP docs to mention packetbeat magefile

### DIFF
--- a/NPCAP.md
+++ b/NPCAP.md
@@ -10,6 +10,8 @@ If you'd like to bump the npcap version please follow the below steps:
 
 Credentials to the artifact service can be found in the `APM-Shared` folder in the password management tool.
 
+4) After you've updated the npcap version in golang-crossbuild, make sure to change the npcap version specified in the [packetbeat magefile](https://github.com/elastic/beats/blob/main/x-pack/packetbeat/magefile.go)
+
 ## Backports
 
 If you'd like to backport any NCAP_VERSION to any existing golang-crosbuild version, then you need to:


### PR DESCRIPTION
Doing this for obvious reasons, it didn't occur to me that packetbeat also cared about the explicit NPCAP version, so adding a bit to the docs here.