### PR TITLE
Improve reliability of builds

### DIFF
--- a/.buildkite/fpm-pipeline.yml
+++ b/.buildkite/fpm-pipeline.yml
@@ -3,6 +3,7 @@
 env:
   SETUP_GVM_VERSION: "v0.5.1"
   IMAGE_UBUNTU_X86_64: "family/core-ubuntu-2204"
+  GCP_DEFAULT_X86_64_MACHINE_TYPE: "n2-standard-16"
   DOCKER_REGISTRY: "docker.elastic.co"
   STAGING_IMAGE: "${DOCKER_REGISTRY}/observability-ci"
   MAKEFILE: "fpm"
@@ -25,3 +26,8 @@ steps:
     agents:
       provider: "gcp"
       image: "${IMAGE_UBUNTU_X86_64}"
+      machineType: "${GCP_DEFAULT_X86_64_MACHINE_TYPE}"
+    retry:
+      automatic:
+        - limit: 1
+

--- a/.buildkite/llvm-apple-pipeline.yml
+++ b/.buildkite/llvm-apple-pipeline.yml
@@ -4,6 +4,7 @@ env:
   SETUP_GVM_VERSION: "v0.5.1"
   IMAGE_UBUNTU_X86_64: "family/core-ubuntu-2204"
   IMAGE_UBUNTU_ARM_64: "core-ubuntu-2004-aarch64"
+  GCP_DEFAULT_X86_64_MACHINE_TYPE: "n2-standard-16"
   DOCKER_REGISTRY: "docker.elastic.co"
   STAGING_IMAGE: "${DOCKER_REGISTRY}/observability-ci"
   MAKEFILE: "go/llvm-apple"
@@ -27,6 +28,10 @@ steps:
     agents:
       provider: "gcp"
       image: "${IMAGE_UBUNTU_X86_64}"
+      machineType: "${GCP_DEFAULT_X86_64_MACHINE_TYPE}"
+    retry:
+      automatic:
+        - limit: 1
     matrix:
       setup:
         debianVersion:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,6 +4,7 @@ env:
   SETUP_GVM_VERSION: "v0.5.1"
   IMAGE_UBUNTU_X86_64: "family/core-ubuntu-2204"
   IMAGE_UBUNTU_ARM_64: "core-ubuntu-2004-aarch64"
+  GCP_DEFAULT_X86_64_MACHINE_TYPE: "n2-standard-16"
   DOCKER_REGISTRY: "docker.elastic.co"
   STAGING_IMAGE: "${DOCKER_REGISTRY}/observability-ci"
   BUILDX: 1
@@ -27,6 +28,10 @@ steps:
         agents:
           provider: "gcp"
           image: "${IMAGE_UBUNTU_X86_64}"
+          machineType: "${GCP_DEFAULT_X86_64_MACHINE_TYPE}"
+        retry:
+          automatic:
+            - limit: 1
         matrix:
           setup:
             makefile:
@@ -67,6 +72,10 @@ steps:
         agents:
           provider: "gcp"
           image: "${IMAGE_UBUNTU_X86_64}"
+          machineType: "${GCP_DEFAULT_X86_64_MACHINE_TYPE}"
+        retry:
+          automatic:
+            - limit: 1
         matrix:
           setup:
             makefile:
@@ -108,3 +117,7 @@ steps:
         agents:
           provider: "gcp"
           image: "${IMAGE_UBUNTU_X86_64}"
+          machineType: "${GCP_DEFAULT_X86_64_MACHINE_TYPE}"
+        retry:
+          automatic:
+            - limit: 1


### PR DESCRIPTION
This commit attempts to improve the reliability of builds from random compilation failures and segfaults by leveraging large instance types and adding a maximum of one retry upon failure.

It's essentially the same as #502 without the libpcap upgrade.

It's based on an internal discussion as a minor interim improvement until a better solution gets implemented.
