### PR TITLE
ci: tidy up functions and scripts unrequired

### DIFF
--- a/.buildkite/scripts/build.sh
+++ b/.buildkite/scripts/build.sh
@@ -8,9 +8,6 @@ MAKEFILE=${1}
 
 check_is_arm
 
-add_bin_path
-with_go "${GOLANG_VERSION}"
-with_mage
 google_cloud_auth
 
 make -C go -f "${MAKEFILE}" build"${is_arm}" GS_BUCKET_PATH=ingest-buildkite-ci
@@ -19,5 +16,3 @@ docker images --format "table {{.Repository}}:{{.Tag}}\t{{.Size}}" --filter=refe
 
 echo ":: List Docker images production ::"
 docker images --format "table {{.Repository}}:{{.Tag}}\t{{.Size}}" --filter=reference="${DOCKER_REGISTRY}/beats-dev/golang-crossbuild"
-
-

--- a/.buildkite/scripts/common.sh
+++ b/.buildkite/scripts/common.sh
@@ -6,71 +6,12 @@ REPO="golang-crossbuild"
 WORKSPACE="$(pwd)"
 BIN="${WORKSPACE}/bin"
 HW_TYPE="$(uname -m)"
-PLATFORM_TYPE="$(uname)"
 TMP_FOLDER="tmp.${REPO}"
 GOOGLE_CREDENTIALS_FILENAME="google-cloud-credentials.json"
 
 if [[ -z "${GOLANG_VERSION-""}" ]]; then
     export GOLANG_VERSION=$(cat "${WORKSPACE}/.go-version")
 fi
-
-add_bin_path() {
-    echo "Adding PATH to the environment variables..."
-    create_bin
-    export PATH="${PATH}:${BIN}"
-}
-
-with_go() {
-    local go_version="${1}"
-    echo "Setting up the Go environment..."
-    create_bin
-    check_platform_architecture
-    retry 5 curl -sL -o ${BIN}/gvm "https://github.com/andrewkroh/gvm/releases/download/${SETUP_GVM_VERSION}/gvm-${PLATFORM_TYPE}-${arch_type}"
-    export PATH="${PATH}:${BIN}"
-    chmod +x ${BIN}/gvm
-    eval "$(gvm "$go_version")"
-    go version
-    which go
-    export PATH="${PATH}:$(go env GOPATH):$(go env GOPATH)/bin"
-}
-
-with_mage() {
-    local install_packages=(
-            "github.com/magefile/mage"
-            "github.com/elastic/go-licenser"
-            "golang.org/x/tools/cmd/goimports"
-            "github.com/jstemmer/go-junit-report"
-            "gotest.tools/gotestsum"
-    )
-    create_bin
-    for pkg in "${install_packages[@]}"; do
-        go install "${pkg}@latest"
-    done
-}
-
-create_bin() {
-    if [[ ! -d "${BIN}" ]]; then
-    mkdir -p ${BIN}
-    fi
-}
-
-check_platform_architecture() {
-# for downloading the GVM and Terraform packages
-  case "${HW_TYPE}" in
-   "x86_64")
-        arch_type="amd64"
-        ;;
-    "aarch64")
-        arch_type="arm64"
-        ;;
-    "arm64")
-        arch_type="arm64"
-        ;;
-    *)
-    echo "The current platform/OS type is unsupported yet"
-    ;;
-  esac
-}
 
 retry() {
     local retries=$1

--- a/.buildkite/scripts/common.sh
+++ b/.buildkite/scripts/common.sh
@@ -13,6 +13,12 @@ if [[ -z "${GOLANG_VERSION-""}" ]]; then
     export GOLANG_VERSION=$(cat "${WORKSPACE}/.go-version")
 fi
 
+create_bin() {
+    if [[ ! -d "${BIN}" ]]; then
+    mkdir -p ${BIN}
+    fi
+}
+
 retry() {
     local retries=$1
     shift

--- a/.buildkite/scripts/common.sh
+++ b/.buildkite/scripts/common.sh
@@ -39,6 +39,7 @@ retry() {
 }
 
 google_cloud_auth() {
+    create_bin
     local gsUtilLocation=$(mktemp -d -p ${BIN} -t "${TMP_FOLDER}.XXXXXXXXX")
     local secretFileLocation=${gsUtilLocation}/${GOOGLE_CREDENTIALS_FILENAME}
     echo "${PRIVATE_CI_GCS_CREDENTIALS_SECRET}" > ${secretFileLocation}

--- a/.buildkite/scripts/llvm-fpm/build.sh
+++ b/.buildkite/scripts/llvm-fpm/build.sh
@@ -12,9 +12,5 @@ if ! are_files_changed "$patterns" ; then
     exit 0
 fi
 
-add_bin_path
-with_go "${GOLANG_VERSION}"
-with_mage
-
 retry 3 make -C "${makefile}" build GS_BUCKET_PATH=ingest-buildkite-ci
 docker images --format "table {{.Repository}}:{{.Tag}}\t{{.Size}}" --filter=reference="${docker_filter_ref}"

--- a/.buildkite/scripts/llvm-fpm/publish.sh
+++ b/.buildkite/scripts/llvm-fpm/publish.sh
@@ -11,5 +11,4 @@ if ! are_files_changed "$patterns" ; then
     exit 0
 fi
 
-add_bin_path
 retry 3 make -C ${makefile} push

--- a/.buildkite/scripts/publish.sh
+++ b/.buildkite/scripts/publish.sh
@@ -7,5 +7,4 @@ source .buildkite/scripts/common.sh
 MAKEFILE=${1}
 
 check_is_arm
-add_bin_path
 retry 3 make -C go -f "${MAKEFILE}" push"${is_arm}"

--- a/go/Makefile.common
+++ b/go/Makefile.common
@@ -17,9 +17,12 @@ export DEBIAN_VERSION TAG_EXTENSION NPCAP_FILE
 
 DOCKER_CMD := docker build
 
-build: copy-npcap copy-sdks
+template:
+	@echo ">> Creating dockerfile from $(patsubst $(PWD)/%,%,$(CURDIR))/Dockerfile.tmpl"
+	@docker run --rm -it -v "$(PWD)":/usr/src -w /usr/src golang:$(VERSION)-alpine go run template.go -t $(patsubst $(PWD)/%,%,$(CURDIR))/Dockerfile.tmpl -o $(patsubst $(PWD)/%,%,$(SELF_DIR1))/Dockerfile
+
+build: copy-npcap copy-sdks template
 	@echo ">> Building $(REPOSITORY)/$(NAME):$(VERSION)$(SUFFIX)$(TAG_EXTENSION)"
-	@go run $(SELF_DIR)/../template.go -t Dockerfile.tmpl -o Dockerfile
 	@$(DOCKER_CMD) -t "$(REPOSITORY)/$(NAME):$(VERSION)$(SUFFIX)$(TAG_EXTENSION)" \
 	--build-arg REPOSITORY=$(REPOSITORY) \
 	--build-arg VERSION=$(VERSION) \


### PR DESCRIPTION
This project uses containers. Therefore, there is no need for `go`/`mage`