### PR TITLE
feat(.buildkite/scripts/buildx.sh): use --progress=plain

### DIFF
--- a/.buildkite/scripts/buildx.sh
+++ b/.buildkite/scripts/buildx.sh
@@ -14,4 +14,4 @@ docker buildx create --name "${BUILDER_NAME}"
 docker buildx use "${BUILDER_NAME}"
 docker buildx inspect --bootstrap
 echo 'Build Docker image'
-docker buildx build --platform "${BUILDPLATFORM}" --push $*
+docker buildx build --progress=plain --platform "${BUILDPLATFORM}" --push $*


### PR DESCRIPTION
For 'docker build buildx' add '--progress=plain' to the arguments
to prevent redrawing of the output which makes it difficult to interpret
the output when viewing CI logs.

It also disables color which makes log output easier to read.
