### PR TITLE
fix(go/base): set GOTOOLCHAIN=local

### DIFF
--- a/go/base-arm/Dockerfile.tmpl
+++ b/go/base-arm/Dockerfile.tmpl
@@ -69,11 +69,12 @@ RUN ldd --version
 WORKDIR /
 
 RUN mkdir -p /root/.config/go/telemetry && echo "off 2024-08-23" > /root/.config/go/telemetry/mode
+ENV GOTOOLCHAIN local
 RUN go mod init github.com/elastic/golang-crossbuild-$GOLANG_VERSION-arm \
     && go get . \
     && go env \
     && echo "toolcompile=$(go tool compile -V)" \
-    && go build -o /crossbuild /entrypoint.go \
+    && CGO_ENABLED=0 GOARCH=arm64 go build -o /crossbuild /entrypoint.go \
     && rm -rf /go/* /root/.cache/* /entrypoint.go
 
 COPY sdks/libpcap-1.8.1.tar.gz . 

--- a/go/base-arm/rootfs/entrypoint.go
+++ b/go/base-arm/rootfs/entrypoint.go
@@ -25,8 +25,8 @@ by mounting the project inside of a container equipped with cross-compilers.
 The root of your project's repo should be mounted at the appropriate location
 on the GOPATH which is set to /go.
 
-While executing the build command the following variables with be added to the
-environment: GOOS, GOARCH, GOARM, PLATFORM_ID, CC, and CXX.
+While executing the build command the following variables will be added to the
+environment: GOOS, GOARCH, GOARM, GOTOOLCHAIN=local, PLATFORM_ID, CC, and CXX.
 `,
 	RunE:         doBuild,
 	SilenceUsage: true,
@@ -104,6 +104,7 @@ func buildEnvironment(platform string) (map[string]string, error) {
 		"GOOS":        goos,
 		"GOARCH":      goarch,
 		"GOARM":       goarm,
+		"GOTOOLCHAIN": "local", // Disable automatic downloads of toolchains for reproducible builds.
 		"PLATFORM_ID": platformID,
 	}
 

--- a/go/base/Dockerfile.tmpl
+++ b/go/base/Dockerfile.tmpl
@@ -62,11 +62,12 @@ RUN ldd --version
 
 WORKDIR /
 RUN mkdir -p /root/.config/go/telemetry && echo "off 2024-08-23" > /root/.config/go/telemetry/mode
+ENV GOTOOLCHAIN=local
 RUN go mod init github.com/elastic/golang-crossbuild-$GOLANG_VERSION \
     && go get . \
     && go env \
     && echo "toolcompile=$(go tool compile -V)" \
-    && CGO_ENABLED=0 go build -o /crossbuild /entrypoint.go \
+    && CGO_ENABLED=0 GOARCH=amd64 go build -o /crossbuild /entrypoint.go \
     && rm -rf /go/* /root/.cache/* /entrypoint.go
 
 COPY sdks/libpcap-1.8.1.tar.gz . 

--- a/go/base/rootfs/entrypoint.go
+++ b/go/base/rootfs/entrypoint.go
@@ -25,8 +25,8 @@ by mounting the project inside of a container equipped with cross-compilers.
 The root of your project's repo should be mounted at the appropriate location
 on the GOPATH which is set to /go.
 
-While executing the build command the following variables with be added to the
-environment: GOOS, GOARCH, GOARM, PLATFORM_ID, CC, and CXX.
+While executing the build command the following variables will be added to the
+environment: GOOS, GOARCH, GOARM, GOTOOLCHAIN=local, PLATFORM_ID, CC, and CXX.
 `,
 	RunE:         doBuild,
 	SilenceUsage: true,
@@ -104,6 +104,7 @@ func buildEnvironment(platform string) (map[string]string, error) {
 		"GOOS":        goos,
 		"GOARCH":      goarch,
 		"GOARM":       goarm,
+		"GOTOOLCHAIN": "local", // Disable automatic downloads of toolchains for reproducible builds.
 		"PLATFORM_ID": platformID,
 	}
 


### PR DESCRIPTION
Disable the automatic downloads of the Go toolchain.

For the goal of reproducible builds using golang-crossbuild, we want all of the binaries used to produce our artifacts to be self-contained in the image. Adding GOTOOLCHAIN=local disable downloads of newer toolchains.

This changes the entrypoint of the images to document that GOTOOLCHAIN is set during builds.  And it sets GOTOOLCHAIN=local in the Dockerfile so that when building entrypoint.go it uses the toolchain that was previously installed.

The two Dockerfiles (base and base-arm) had different 'go build' commands. This unifies them to both have CGO_ENABLED=0 and to explicitly set GOARCH to avoid accidentally producing a binary for the wrong target architecture (which we've seen happen for unknown reasons).

https://go.dev/doc/toolchain