### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 * @elastic/elastic-agent-control-plane
 
 # Ownership of CI or related files by the Ingest Eng Prod team
-/.buildkite @elastic/ingest-eng-prod
-/catalog-info.yaml @elastic/ingest-eng-prod
+/.buildkite @elastic/observablt-ci @elastic/observablt-ci-contractors
+/catalog-info.yaml @elastic/observablt-ci @elastic/observablt-ci-contractors


### PR DESCRIPTION
We are deprecating the GH team called `ingest-eng-prod`:

For such, we are now using two GH teams:
- @elastic/observablt-ci 
- @elastic/observablt-ci-contractors


The error is expected in the CODEOWNERS, the permissions will be changed in a follow-up