### PR TITLE
bump 1.24.0 version

### DIFF
--- a/go/Makefile.common
+++ b/go/Makefile.common
@@ -2,7 +2,7 @@ SELF_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
 include $(SELF_DIR)/../Makefile.common
 
 NAME           := golang-crossbuild
-VERSION        := 1.23.6
+VERSION        := 1.24.0
 DEBIAN_VERSION ?= 9
 SUFFIX         := -$(shell basename $(CURDIR))
 TAG_EXTENSION  ?=


### PR DESCRIPTION
`1.24.0` version was not updated in the Makefile.

I think that's related to some updates in the version of the updatecli introduced in https://github.com/elastic/golang-crossbuild/pull/470


