### PR TITLE
Revert "build(deps): bump the github-actions group across 1 directory with 2 updates"

### DIFF
--- a/.github/actions/bump-golang/action.yml
+++ b/.github/actions/bump-golang/action.yml
@@ -33,7 +33,7 @@ runs:
           ref: ${{ inputs.branch }}
 
       - name: Install Updatecli in the runner
-        uses: updatecli/updatecli-action@92a13b95c2cd9f1c6742c965509203c6a5635ed7 # v2.68.0
+        uses: updatecli/updatecli-action@3a8785d88ec4fa03d86521a181f37c0e74627463 # v2.64.0
 
       - name: Run Updatecli in Apply mode
         run: updatecli ${{ env.COMMAND }} --config ./.github/updatecli.d/bump-golang.yml
@@ -45,7 +45,7 @@ runs:
         shell: bash
 
       - if: ${{ failure()  }}
-        uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
+        uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e # v1.26.0
         with:
           channel-id: ${{ inputs.slack-channel-id }}
           payload: |


### PR DESCRIPTION
Reverts elastic/golang-crossbuild#470

I think this is causing some issues when force-update happens and some commits are lost.

