### PR TITLE
buildkite: support for npcap releases or urgency releases

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -75,8 +75,8 @@ steps:
           - ".buildkite/scripts/publish.sh {{matrix.makefile}}"
         env:
           FIPS: "{{matrix.fips}}"
-        # Releases should only be for main for ^[0-9].[0-9] branches (therefore support for x.y.z.x).
-        if: build.branch == "main" || build.branch =~ /^[0-9]+\.[0-9]+/
+        # Releases should only be for main for ^[0-9].[0-9] branches (therefore support for major.minor.patch.x too).
+        if: build.branch == "main" || build.branch =~ /^[0-9]+\.[0-9]+/ || build.branch =~ /^[0-9]+\.[0-9]+\.[0-9]+\.x$$/
         agents:
           provider: "gcp"
           image: "${IMAGE_UBUNTU_X86_64}"
@@ -103,8 +103,8 @@ steps:
           - ".buildkite/scripts/publish.sh Makefile.debian9"
         env:
           FIPS: "{{matrix.fips}}"
-        # Releases should only be for main for ^[0-9].[0-9] branches (therefore support for x.y.z.x).
-        if: build.branch == "main" || build.branch =~ /^[0-9]+\.[0-9]+/
+        # Releases should only be for main for ^[0-9].[0-9] branches (therefore support for major.minor.patch.x too).
+        if: build.branch == "main" || build.branch =~ /^[0-9]+\.[0-9]+$$/ || build.branch =~ /^[0-9]+\.[0-9]+\.[0-9]+\.x$$/
         agents:
           provider: "aws"
           imagePrefix: "${IMAGE_UBUNTU_ARM_64}"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -75,7 +75,8 @@ steps:
           - ".buildkite/scripts/publish.sh {{matrix.makefile}}"
         env:
           FIPS: "{{matrix.fips}}"
-        if: build.branch == "main" || build.branch =~ /^[0-9]+\.[0-9]+$$/
+        # Releases should only be for main for ^[0-9].[0-9] branches (therefore support for x.y.z.x).
+        if: build.branch == "main" || build.branch =~ /^[0-9]+\.[0-9]+/
         agents:
           provider: "gcp"
           image: "${IMAGE_UBUNTU_X86_64}"
@@ -102,7 +103,8 @@ steps:
           - ".buildkite/scripts/publish.sh Makefile.debian9"
         env:
           FIPS: "{{matrix.fips}}"
-        if: build.branch == "main" || build.branch =~ /^[0-9]+\.[0-9]+$$/
+        # Releases should only be for main for ^[0-9].[0-9] branches (therefore support for x.y.z.x).
+        if: build.branch == "main" || build.branch =~ /^[0-9]+\.[0-9]+/
         agents:
           provider: "aws"
           imagePrefix: "${IMAGE_UBUNTU_ARM_64}"
@@ -119,6 +121,7 @@ steps:
       - label: "Post-Release"
         key: "release-post"
         command: ".buildkite/scripts/post-release.sh ${GOLANG_VERSION}"
+        # Releases should only be for main for ^[0-9].[0-9]$ branches.
         if: build.branch == "main" || build.branch =~ /^[0-9]+\.[0-9]+$$/
         depends_on:
           - "release-ubuntu-x86"


### PR DESCRIPTION
See https://github.com/elastic/golang-crossbuild/blob/main/NPCAP.md#backports

There is the concept of `major.minor.patch.x` for cases that need to change an existing Golang Crossbuild release with something else. 

We have used that in some cases such as the NPCAP in the past, and recently at https://github.com/elastic/golang-crossbuild/pull/554

But the existing conditions in the BK pipeline didn't allow to actually proceed.

In my view, we should allow running releases for:

- main
- ^[0-9]+.[0-9]+$
- ^[0-9]+.[0-9]+

This should help with cases such as:
- `main`
- `1.24`
- `1.24.0.x`
