### PR TITLE
Strip microsoft/go pre-release identifier

### DIFF
--- a/go/base-arm/Dockerfile.tmpl
+++ b/go/base-arm/Dockerfile.tmpl
@@ -59,7 +59,7 @@ RUN \
 
 ARG GOLANG_VERSION=1.24.1
 {{- if eq .FIPS "true"}}
-ARG GOLANG_DOWNLOAD_URL=https://aka.ms/golang/release/latest/go$GOLANG_VERSION-1.linux-arm64.tar.gz
+ARG GOLANG_DOWNLOAD_URL=https://aka.ms/golang/release/latest/go$GOLANG_VERSION.linux-arm64.tar.gz
 # Use a different arg name for microsoft/go sha so it can be handled seperately from the regular golang sha
 ARG MSFT_DOWNLOAD_SHA256=73b1befea457d5967632b2b0b93f8d2c0d899d5b6fbd1396c55d0a015292608b
 ARG DOWNLOAD_SHA256=$MSFT_DOWNLOAD_SHA256

--- a/go/base/Dockerfile.tmpl
+++ b/go/base/Dockerfile.tmpl
@@ -33,7 +33,7 @@ RUN ln -s /usr/bin/pip3 /usr/bin/pip
 
 ARG GOLANG_VERSION=1.24.1
 {{- if eq .FIPS "true"}}
-ARG GOLANG_DOWNLOAD_URL=https://aka.ms/golang/release/latest/go$GOLANG_VERSION-1.linux-amd64.tar.gz
+ARG GOLANG_DOWNLOAD_URL=https://aka.ms/golang/release/latest/go$GOLANG_VERSION.linux-amd64.tar.gz
 # Use a different arg name for microsoft/go sha so it can be handled seperately from the regular golang sha
 ARG MSFT_DOWNLOAD_SHA256=b0ca85ecc435a93e2ddb626dd9ef7fb6689700a0847b0392eb3e146345a8dea0
 ARG DOWNLOAD_SHA256=$MSFT_DOWNLOAD_SHA256


### PR DESCRIPTION
Strip static coded microsoft/go prerelease identifier from download.
The microsoft/go toolchain may include separate patches (from upstream) that are designated with a prerelease identifier, i.e., `v1.24.1-1` or `v1.24.1-2` (note: the current microsoft/go patches to `v1.24.1` only change their test infrastructure and not the binary).
Release are listed in their github: https://github.com/microsoft/go/releases
Not using a pre-release identifier uses the latest available one (this is consistent with how we gather the SHA256 checksums).

