### PR TITLE
updatecli: microsoft security patches

### DIFF
--- a/.github/actions/bump-golang/action.yml
+++ b/.github/actions/bump-golang/action.yml
@@ -36,7 +36,7 @@ runs:
         uses: updatecli/updatecli-action@92a13b95c2cd9f1c6742c965509203c6a5635ed7 # v2.68.0
 
       - name: Run Updatecli in Apply mode
-        run: updatecli ${{ env.COMMAND }} --config ./.github/updatecli.d/bump-golang.yml
+        run: updatecli ${{ env.COMMAND }} --config ./.github/updatecli.d/
         env:
           COMMAND: ${{ inputs.command }}
           BRANCH: ${{ inputs.branch }}

--- a/.github/updatecli.d/bump-go-microsoft-version.sh
+++ b/.github/updatecli.d/bump-go-microsoft-version.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# Given the Golang microsoft version this script will bump the version.
+#
+# This script is executed by the automation we are putting in place
+#
+# Parameters:
+#	$1 -> the Golang release version to be bumped. Mandatory.
+#
+set -euo pipefail
+MSG="parameter missing."
+GO_RELEASE_VERSION=${1:?$MSG}
+OS=$(uname -s| tr '[:upper:]' '[:lower:]')
+if [ "${OS}" == "darwin" ] ; then
+	SED="sed -i .bck"
+else
+	SED="sed -i"
+fi
+
+MAJOR_MINOR_PATCH_VERSION=$(echo "$GO_RELEASE_VERSION" | sed -E -e "s#([0-9]+\.[0-9]+\.[0-9]+).*#\1#g")
+SECURITY_VERSION=$(echo "$GO_RELEASE_VERSION" | sed -E -e "s#([0-9]+\.[0-9]+\.[0-9]+)(.+)#\2#g")
+
+# Gather microsoft/go sha256 values
+MSFT_DOWNLOAD_METADATA=$(curl -s -L https://aka.ms/golang/release/latest/go${MAJOR_MINOR_PATCH_VERSION}.assets.json)
+MSFT_DOWNLOAD_SHA256_ARM=$(echo $MSFT_DOWNLOAD_METADATA | jq -r ".arches[] | select( .env.GOOS == \"linux\") | select( .env.GOARCH == \"arm64\") | .sha256")
+MSFT_DOWNLOAD_SHA256_AMD=$(echo $MSFT_DOWNLOAD_METADATA | jq -r ".arches[] | select( .env.GOOS == \"linux\") | select( .env.GOARCH == \"amd64\") | .sha256")
+
+echo "Update go version ${GO_RELEASE_VERSION}"
+
+find "go" -type f -name Dockerfile.tmpl -print0 |
+    while IFS= read -r -d '' line; do
+        ${SED} -E -e "s#(ARG GOLANG_VERSION)=[0-9]+\.[0-9]+(\.[0-9]+)?#\1=${MAJOR_MINOR_PATCH_VERSION}#g" "$line"
+        if echo "$line" | grep -q 'arm' ; then
+            ${SED} -E -e "s#(ARG MSFT_DOWNLOAD_SHA256)=.+#\1=${MSFT_DOWNLOAD_SHA256_ARM}#g" "$line"
+            ${SED} -E -e "s#(ARG SECURITY_VERSION)=.+#\1=${SECURITY_VERSION}#g" "$line"
+        else
+            ${SED} -E -e "s#(ARG MSFT_DOWNLOAD_SHA256)=.+#\1=${MSFT_DOWNLOAD_SHA256_AMD}#g" "$line"
+            ${SED} -E -e "s#(ARG SECURITY_VERSION)=.+#\1=${SECURITY_VERSION}#g" "$line"
+        fi
+    done

--- a/.github/updatecli.d/bump-microsoft.yml
+++ b/.github/updatecli.d/bump-microsoft.yml
@@ -1,6 +1,6 @@
 ---
 name: Bump golang-microsoft to latest version
-pipelineid: 'bump-golang-version-{{ requiredEnv "BRANCH" }}'
+pipelineid: 'bump-golang-microsoft-version-{{ requiredEnv "BRANCH" }}'
 
 scms:
   githubConfig:
@@ -26,7 +26,7 @@ actions:
         - dependencies
         - backport-skip
       description: |
-        See [changelog](https://github.com/golang/go/issues?q=milestone%3AGo{{ source "latestGoVersion" }}+label%3ACherryPickApproved) for {{ source "latestGoVersion" }}
+        See https://github.com/microsoft/go/releases/v{{ source "latestGoVersion" }}
 
 sources:
   minor:

--- a/.github/updatecli.d/bump-microsoft.yml
+++ b/.github/updatecli.d/bump-microsoft.yml
@@ -1,0 +1,67 @@
+---
+name: Bump golang-microsoft to latest version
+pipelineid: 'bump-golang-version-{{ requiredEnv "BRANCH" }}'
+
+scms:
+  githubConfig:
+    kind: github
+    spec:
+      user: '{{ requiredEnv "GITHUB_ACTOR" }}'
+      username: '{{ requiredEnv "GITHUB_ACTOR" }}'
+      owner: elastic
+      repository: golang-crossbuild
+      token: '{{ requiredEnv "GITHUB_TOKEN" }}'
+      branch: '{{ requiredEnv "BRANCH" }}'
+      commitusingapi: true
+
+actions:
+  default:
+    title: '[Automation] Bump Microsoft version to {{ source "latestGoVersion" }}'
+    kind: github/pullrequest
+    scmid: githubConfig
+    spec:
+      automerge: true
+      labels:
+        - automation
+        - dependencies
+        - backport-skip
+      description: |
+        See [changelog](https://github.com/golang/go/issues?q=milestone%3AGo{{ source "latestGoVersion" }}+label%3ACherryPickApproved) for {{ source "latestGoVersion" }}
+
+sources:
+  minor:
+    name: Get minor version
+    kind: shell
+    transformers:
+      - findsubmatch:
+          pattern: '^\d+.(\d+)'
+          captureindex: 1
+    spec:
+      command: echo {{ requiredEnv "GO_MINOR" }}
+
+  latestGoVersion:
+    name: Get Latest Go Release
+    kind: githubrelease
+    dependson:
+      - minor
+    transformers:
+      - trimprefix: v
+    spec:
+      owner: microsoft
+      repository: go
+      token: '{{ requiredEnv "GITHUB_TOKEN" }}'
+      username: '{{ requiredEnv "GITHUB_ACTOR" }}'
+      versionfilter:
+        kind: regex
+        pattern: v1\.{{ source "minor" }}\.(\d*)-(\d*)$
+
+targets:
+  update-go-versions:
+    name: 'Update go version {{ source "latestGoVersion" }}'
+    kind: shell
+    sourceid: latestGoVersion
+    scmid: githubConfig
+    spec:
+      command: .github/updatecli.d/bump-go-microsoft-version.sh
+      environments:
+        - name: PATH

--- a/go/base-arm/Dockerfile.tmpl
+++ b/go/base-arm/Dockerfile.tmpl
@@ -59,7 +59,8 @@ RUN \
 
 ARG GOLANG_VERSION=1.24.1
 {{- if eq .FIPS "true"}}
-ARG GOLANG_DOWNLOAD_URL=https://aka.ms/golang/release/latest/go$GOLANG_VERSION-1.linux-arm64.tar.gz
+ARG SECURITY_VERSION=-1
+ARG GOLANG_DOWNLOAD_URL=https://aka.ms/golang/release/latest/go$GOLANG_VERSION$SECURITY_VERSION.linux-arm64.tar.gz
 # Use a different arg name for microsoft/go sha so it can be handled seperately from the regular golang sha
 ARG MSFT_DOWNLOAD_SHA256=73b1befea457d5967632b2b0b93f8d2c0d899d5b6fbd1396c55d0a015292608b
 ARG DOWNLOAD_SHA256=$MSFT_DOWNLOAD_SHA256

--- a/go/base/Dockerfile.tmpl
+++ b/go/base/Dockerfile.tmpl
@@ -33,7 +33,8 @@ RUN ln -s /usr/bin/pip3 /usr/bin/pip
 
 ARG GOLANG_VERSION=1.24.1
 {{- if eq .FIPS "true"}}
-ARG GOLANG_DOWNLOAD_URL=https://aka.ms/golang/release/latest/go$GOLANG_VERSION-1.linux-amd64.tar.gz
+ARG SECURITY_VERSION=-1
+ARG GOLANG_DOWNLOAD_URL=https://aka.ms/golang/release/latest/go$GOLANG_VERSION$SECURITY_VERSION.linux-amd64.tar.gz
 # Use a different arg name for microsoft/go sha so it can be handled seperately from the regular golang sha
 ARG MSFT_DOWNLOAD_SHA256=b0ca85ecc435a93e2ddb626dd9ef7fb6689700a0847b0392eb3e146345a8dea0
 ARG DOWNLOAD_SHA256=$MSFT_DOWNLOAD_SHA256


### PR DESCRIPTION
### What

Support patch security versions for the Microsoft golang:

- https://github.com/elastic/golang-crossbuild/pull/565#issuecomment-2767102516

### Why

Otherwise, we won't be able to create a golang crossbuild docker image with the latest Microsoft golang version. Bear in mind, we use major.minor.patch format.

### Test

When I ran

```bash
$ 
GO_MINOR=1.24 GITHUB_TOKEN=$(gh auth token) \
  GITHUB_ACTOR=v1v BRANCH=test/my-previous-version \
  updatecli apply --config .github/updatecli.d/
```

It created https://github.com/v1v/golang-crossbuild/pull/8

```


+++++++++++
+ PREPARE +
+++++++++++

Loading Pipeline ".github/updatecli.d/bump-go-microsoft-version.sh"
Loading Pipeline ".github/updatecli.d/bump-go-release-version.sh"
Loading Pipeline ".github/updatecli.d/bump-golang.yml"
Loading Pipeline ".github/updatecli.d/bump-microsoft.yml"

SCM repository retrieved: 1


++++++++++++++++++
+ AUTO DISCOVERY +
++++++++++++++++++



++++++++++++
+ PIPELINE +
++++++++++++



#########################################
# BUMP GOLANG-VERSION TO LATEST VERSION #
#########################################

source: source#minor
------------
The shell 🐚 command "/bin/sh /var/folders/t7/ghqdh8cx2g12pwb_w0ncmw900000gn/T/updatecli/bin/ce9bcd193ec6e5a1e6ebd3db2acc588dbac213b3becccf2cecace489e1cd70c9.sh" ran successfully with the following output:
----
1.24
----
✔ shell command executed successfully
[transformers]
✔ Result correctly transformed from "1.24" to "24"

source: source#latestGoVersion
----------------------
WARNING: ⚠ No GitHub Release found, we fallback to published git tags
Searching for version matching pattern "go1\\.24(\\.(\\d*))?$"
✔ GitHub release version "go1.24.1" found matching pattern "go1\\.24(\\.(\\d*))?$" of kind "regex"
[transformers]
✔ Result correctly transformed from "go1.24.1" to "1.24.1"


CHANGELOG:
----------
no GitHub Release found for go1.24.1 on "https://github.com/golang/go"

condition: condition#dockerTag
-------------------
✔ docker image golang:1.24.1 found

condition: condition#is-already-updated
----------------------------
The shell 🐚 command "/bin/sh /var/folders/t7/ghqdh8cx2g12pwb_w0ncmw900000gn/T/updatecli/bin/24acc117942e580708f61a3b4f62eebf963e8f541f0a16f738b7c19faf4c8c54.sh" exited on error (exit code 1) with the following output:
----
VERSION        := 1.24.1
----

command stderr output was:
----
----
shell command failed. Expected exit code 0 but got 1
✗ shell condition of type "console/output" not passing

target: target#update-go-versions
-------------------------

target: target#update-go-makefile.common
--------------------------------

target: target#update-go-version
------------------------


###########################################
# BUMP GOLANG-MICROSOFT TO LATEST VERSION #
###########################################

source: source#minor
------------
The shell 🐚 command "/bin/sh /var/folders/t7/ghqdh8cx2g12pwb_w0ncmw900000gn/T/updatecli/bin/ce9bcd193ec6e5a1e6ebd3db2acc588dbac213b3becccf2cecace489e1cd70c9.sh" ran successfully with the following output:
----
1.24
----
✔ shell command executed successfully
[transformers]
✔ Result correctly transformed from "1.24" to "24"

source: source#latestGoVersion
----------------------
Searching for version matching pattern "v1\\.24\\.(\\d*)-(\\d*)$"
✔ GitHub release version "v1.24.1-6" found matching pattern "v1\\.24\\.(\\d*)-(\\d*)$" of kind "regex"
[transformers]
✔ Result correctly transformed from "v1.24.1-6" to "1.24.1-6"


CHANGELOG:
----------

Release published on the 2025-03-12 20:56:46 +0000 UTC at the url https://github.com/microsoft/go/releases/tag/v1.24.1-6

Microsoft build of Go v1.24.1-6

No changes since v1.24.1-1. This release was run to test infrastructure changes end to end.

target: target#update-go-versions
-------------------------
The shell 🐚 command "/bin/sh /var/folders/t7/ghqdh8cx2g12pwb_w0ncmw900000gn/T/updatecli/bin/9964bc3741abca3ecbd421d637938243fc572271121fc0b19611ba8350150fe0.sh" ran successfully with the following output:
----
Update go version 1.24.1-6
----
⚠ - ran shell command ".github/updatecli.d/bump-go-microsoft-version.sh 1.24.1-6"


ACTIONS
========


Bump golang-version to latest version
  => [Automation] Bump Golang version to 1.24.1

No follow up action needed

Bump golang-microsoft to latest version
  => [Automation] Bump Microsoft version to 1.24.1-6


Pull Request available at:

	https://github.com/v1v/golang-crossbuild/pull/8

Existing GitHub pull request found: https://github.com/v1v/golang-crossbuild/pull/8

=============================

SUMMARY:



- Bump golang-version to latest version:
	Source:
		✔ [latestGoVersion] Get Latest Go Release
		✔ [minor] Get minor version
	Condition:
		✔ [dockerTag] Is docker image golang:1.24.1 published
		✗ [is-already-updated] Is version '1.24.1' not updated in 'go/Makefile.common'?
	Target:
		- [update-go-makefile.common] 
		- [update-go-version] 
		- [update-go-versions] 


⚠ Bump golang-microsoft to latest version:
	Source:
		✔ [latestGoVersion] Get Latest Go Release
		✔ [minor] Get minor version
	Target:
		⚠ [update-go-versions] Update go version 1.24.1-6


Run Summary
===========
Pipeline(s) run:
  * Changed:	1
  * Failed:	0
  * Skipped:	1
  * Succeeded:	0
  * Total:	2

One action to follow up:
  * https://github.com/v1v/golang-crossbuild/pull/8
```