### PR TITLE
updatecli: add condition for assets.json

### DIFF
--- a/.github/updatecli.d/bump-golang.yml
+++ b/.github/updatecli.d/bump-golang.yml
@@ -82,6 +82,13 @@ conditions:
     spec:
       command: grep 'VERSION        := {{ source `latestGoVersion` }}' go/Makefile.common && exit 1 || exit 0
     failwhen: false
+  is-not-available:
+    name: Is assets.json available?
+    kind: file
+    disablesourceinput: true
+    spec:
+      file: https://aka.ms/golang/release/latest/go{{ source `latestGoVersion` }}.assets.json
+    failwhen: true
 
 targets:
   update-go-version:


### PR DESCRIPTION
This should help when the assets.json is not available.

Closes https://github.com/elastic/golang-crossbuild/issues/571


```bash 
$ GO_MINOR=1.24 GITHUB_TOKEN=$(gh auth token) \
  GITHUB_ACTOR=v1v BRANCH=main \
  updatecli apply --config .github/updatecli.d/bump-golang.yml
```

```
condition: condition#is-not-available
--------------------------
✗ condition on file ["https://aka.ms/golang/release/latest/go1.24.2.assets.json"] passed

condition: condition#dockerTag
-------------------
✔ docker image golang:1.24.2 found

condition: condition#is-already-updated
----------------------------
The shell 🐚 command "/bin/sh /var/folders/t7/ghqdh8cx2g12pwb_w0ncmw900000gn/T/updatecli/bin/930c7a665b94254478ed7050ad905da920eb37a219b5e35b90beba13d0afcab2.sh" ran successfully with the following output:
----
----
✔ shell condition of type "console/output", passing

target: target#update-go-makefile.common
--------------------------------

target: target#update-go-versions
-------------------------

target: target#update-go-version
------------------------

ACTIONS
========

Bump golang-version to latest version
  => [Automation] Bump Golang version to 1.24.2

Existing GitHub pull request found: https://github.com/elastic/golang-crossbuild/pull/570
Existing GitHub pull request found: https://github.com/elastic/golang-crossbuild/pull/570

=============================

SUMMARY:

- Bump golang-version to latest version:
	Source:
		✔ [latestGoVersion] Get Latest Go Release
		✔ [minor] Get minor version
	Condition:
		✔ [dockerTag] Is docker image golang:1.24.2 published
		✔ [is-already-updated] Is version '1.24.2' not updated in 'go/Makefile.common'?
		✗ [is-not-available] Is assets.json available?
	Target:
		- [update-go-makefile.common] 
		- [update-go-version] 
		- [update-go-versions] 


Run Summary
===========
Pipeline(s) run:
  * Changed:	0
  * Failed:	0
  * Skipped:	1
  * Succeeded:	0
  * Total:	1
```