### PR TITLE
bk: stop cancelling any builds for the `1.*` golang branches

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -47,9 +47,9 @@ spec:
           build.pull_request.id == null || (build.creator.name == 'elasticmachine' && build.pull_request.id != null)
       repository: elastic/golang-crossbuild
       cancel_intermediate_builds: true
-      cancel_intermediate_builds_branch_filter: '!main'
+      cancel_intermediate_builds_branch_filter: '!main !1.*'
       skip_intermediate_builds: true
-      skip_intermediate_builds_branch_filter: '!main'
+      skip_intermediate_builds_branch_filter: '!main !1.*'
       env:
          ELASTIC_PR_COMMENTS_ENABLED: 'true'
       teams:


### PR DESCRIPTION
https://github.com/elastic/golang-crossbuild/pull/299/ create the foundations but, `1.24` or any other `major.minor` branches should not be cancelled if a new merge commit is merged.

<img width="944" alt="image" src="https://github.com/user-attachments/assets/beae1f21-bb36-4de4-8f6d-1870385347b9" />

https://buildkite.com/elastic/golang-crossbuild/builds/1000#0196107a-e646-476b-aac1-a1d86ea07735