### PR TITLE
updatecli: add conditions for the security version

### DIFF
--- a/.github/updatecli.d/bump-microsoft.yml
+++ b/.github/updatecli.d/bump-microsoft.yml
@@ -74,7 +74,7 @@ conditions:
     kind: shell
     spec:
       command: grep 'ARG SECURITY_VERSION={{ source `securityVersion` }}' go/base/Dockerfile.tmpl && exit 1 || exit 0
-    failwhen: true
+    failwhen: false
 
 targets:
   update-go-versions:

--- a/.github/updatecli.d/bump-microsoft.yml
+++ b/.github/updatecli.d/bump-microsoft.yml
@@ -55,7 +55,7 @@ sources:
         kind: regex
         pattern: v1\.{{ source "minor" }}\.(\d*)-(\d*)$
 
-  security:
+  securityVersion:
     name: Get security version
     dependson:
       - latestGoVersion
@@ -63,17 +63,17 @@ sources:
     transformers:
       - findsubmatch:
           pattern: '^1.{{ source "minor" }}.\d+-(\d+)'
-          captureindex: 2
+          captureindex: 1
     spec:
       command: echo {{ source "latestGoVersion" }}
 
 conditions:
   is-already-updated:
-    name: Is security version '{{ source "security" }}' not updated in 'go/base/Dockerfile.tmpl'?
+    name: Is security version '{{ source "securityVersion" }}' not updated in 'go/base/Dockerfile.tmpl'?
     disablesourceinput: true
     kind: shell
     spec:
-      command: grep 'ARG SECURITY_VERSION={{ source `security` }}' go/base/Dockerfile.tmpl && exit 1 || exit 0
+      command: grep 'ARG SECURITY_VERSION={{ source `securityVersion` }}' go/base/Dockerfile.tmpl && exit 1 || exit 0
     failwhen: false
 
 targets:

--- a/.github/updatecli.d/bump-microsoft.yml
+++ b/.github/updatecli.d/bump-microsoft.yml
@@ -74,7 +74,7 @@ conditions:
     kind: shell
     spec:
       command: grep 'ARG SECURITY_VERSION={{ source `securityVersion` }}' go/base/Dockerfile.tmpl && exit 1 || exit 0
-    failwhen: false
+    failwhen: true
 
 targets:
   update-go-versions:

--- a/.github/updatecli.d/bump-microsoft.yml
+++ b/.github/updatecli.d/bump-microsoft.yml
@@ -53,7 +53,7 @@ sources:
       username: '{{ requiredEnv "GITHUB_ACTOR" }}'
       versionfilter:
         kind: regex
-        pattern: v1\.{{ source "minor" }}\.(\d*)-(\d*)$
+        pattern: v1\.{{ source "minor" }}\.(\d*)(-\d*)$
 
   securityVersion:
     name: Get security version
@@ -62,7 +62,7 @@ sources:
     kind: shell
     transformers:
       - findsubmatch:
-          pattern: '^1.{{ source "minor" }}.\d+-(\d+)'
+          pattern: '^1.{{ source "minor" }}.\d+(-\d+)'
           captureindex: 1
     spec:
       command: echo {{ source "latestGoVersion" }}

--- a/.github/updatecli.d/bump-microsoft.yml
+++ b/.github/updatecli.d/bump-microsoft.yml
@@ -55,6 +55,27 @@ sources:
         kind: regex
         pattern: v1\.{{ source "minor" }}\.(\d*)-(\d*)$
 
+  security:
+    name: Get security version
+    dependson:
+      - latestGoVersion
+    kind: shell
+    transformers:
+      - findsubmatch:
+          pattern: '^1.{{ source "minor" }}.\d+-(\d+)'
+          captureindex: 2
+    spec:
+      command: echo {{ source "latestGoVersion" }}
+
+conditions:
+  is-already-updated:
+    name: Is security version '{{ source "security" }}' not updated in 'go/base/Dockerfile.tmpl'?
+    disablesourceinput: true
+    kind: shell
+    spec:
+      command: grep 'ARG SECURITY_VERSION={{ source `security` }}' go/base/Dockerfile.tmpl && exit 1 || exit 0
+    failwhen: false
+
 targets:
   update-go-versions:
     name: 'Update go version {{ source "latestGoVersion" }}'


### PR DESCRIPTION
### What

Needs conditionals to avoid [failing](https://github.com/elastic/golang-crossbuild/actions/runs/14769064076/job/41465887703) when the PR has already raised.

<img width="736" alt="image" src="https://github.com/user-attachments/assets/b6eaa8ec-2298-40ce-a305-1932ef9bf2ae" />



### Test

See https://github.com/elastic/golang-crossbuild/actions/runs/14774735610/attempts/1 if no PR but required changes

```
⚠ Bump golang-microsoft to latest version:
	Source:
		✔ [latestGoVersion] Get Latest Go Release
		✔ [minor] Get minor version
		✔ [securityVersion] Get security version
	Condition:
		✔ [is-already-updated] Is security version '-2' not updated in 'go/base/Dockerfile.tmpl'?
	Target:
		⚠ [update-go-versions] Update go version 1.24.2-2

```


See https://github.com/elastic/golang-crossbuild/actions/runs/14774735610/attempts/2 if PR exists with the required changes

```

Bump golang-microsoft to latest version - default
-------------------------------------------------


Pull Request available at:

	https://github.com/elastic/golang-crossbuild/pull/598

ERROR: action stage:	"Pull request Pull request is in unstable status"
Existing GitHub pull request found: https://github.com/elastic/golang-crossbuild/pull/598
ERROR: running actions:
errors occurred while running actions:
	* Pull request Pull request is in unstable status
...


⚠ Bump golang-microsoft to latest version:
	Source:
		✔ [latestGoVersion] Get Latest Go Release
		✔ [minor] Get minor version
		✔ [securityVersion] Get security version
	Condition:
		✔ [is-already-updated] Is security version '-2' not updated in 'go/base/Dockerfile.tmpl'?
	Target:
		⚠ [update-go-versions] Update go version 1.24.2-2


```

### Locally

```bash
$ GITHUB_TOKEN=$(gh auth token) GITHUB_ACTOR=v1v BRANCH=main GO_MINOR=1.24 ./updatecli --experimental apply --config ./.github/updatecli.d/bump-microsoft.yml --push=false --commit=false --clean=true
```

or 

```bash
$  GITHUB_TOKEN=$(gh auth token) GITHUB_ACTOR=v1v BRANCH=main GO_MINOR=1.24 ./updatecli --experimental apply --config ./.github/updatecli.d/bump-microsoft.yml                 


Bump golang-microsoft to latest version - default
-------------------------------------------------


Pull Request available at:

	https://github.com/elastic/golang-crossbuild/pull/599

Existing GitHub pull request found: https://github.com/elastic/golang-crossbuild/pull/599


UDASH - EXPERIMENTAL
=====================

Skipping as no Udash configuration file found at /Users/vmartinez/Library/Application Support/updatecli/udash.json

=============================

SUMMARY:



⚠ Bump golang-microsoft to latest version:
	Source:
		✔ [latestGoVersion] Get Latest Go Release
		✔ [minor] Get minor version
		✔ [securityVersion] Get security version
	Condition:
		✔ [is-already-updated] Is security version '-2' not updated in 'go/base/Dockerfile.tmpl'?
	Target:
		⚠ [update-go-versions] Update go version 1.24.2-2
```

