### PR TITLE
catalog-info: avoid spamming builds for no runs

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -104,7 +104,7 @@ spec:
       skip_intermediate_builds: true
       skip_intermediate_builds_branch_filter: '!main'
       env:
-        ELASTIC_PR_COMMENTS_ENABLED: 'true'
+        ELASTIC_PR_COMMENTS_ENABLED: 'false'
       teams:
         ingest-fp:
           access_level: MANAGE_BUILD_AND_READ
@@ -152,7 +152,7 @@ spec:
       skip_intermediate_builds: true
       skip_intermediate_builds_branch_filter: '!main'
       env:
-        ELASTIC_PR_COMMENTS_ENABLED: 'true'
+        ELASTIC_PR_COMMENTS_ENABLED: 'false'
       teams:
         ingest-fp:
           access_level: MANAGE_BUILD_AND_READ


### PR DESCRIPTION
There are three different pipelines:
- fpm
- apple-llvm
- normal-ci

The first two don't normally change, hence we need only messages for `normal-ci`. This should avoid multiple GH comments with the build status when the build status does nothing.,

Unfortunately, the current BK implementation uses a runtime change file detection and hence it runs even if no build is needed...

This should help with keeping the GH build notifications smart and clean.