### PR TITLE
updatecli: run bump-golang and bump-go-microsoft independent

### DIFF
--- a/.github/updatecli.d/bump-go-microsoft-version.sh
+++ b/.github/updatecli.d/bump-go-microsoft-version.sh
@@ -29,12 +29,10 @@ echo "Update go version ${GO_RELEASE_VERSION}"
 
 find "go" -type f -name Dockerfile.tmpl -print0 |
     while IFS= read -r -d '' line; do
-        ${SED} -E -e "s#(ARG GOLANG_VERSION)=[0-9]+\.[0-9]+(\.[0-9]+)?#\1=${MAJOR_MINOR_PATCH_VERSION}#g" "$line"
+        ${SED} -E -e "s#(ARG SECURITY_VERSION)=.*#\1=${SECURITY_VERSION}#g" "$line"
         if echo "$line" | grep -q 'arm' ; then
             ${SED} -E -e "s#(ARG MSFT_DOWNLOAD_SHA256)=.+#\1=${MSFT_DOWNLOAD_SHA256_ARM}#g" "$line"
-            ${SED} -E -e "s#(ARG SECURITY_VERSION)=.*#\1=${SECURITY_VERSION}#g" "$line"
         else
             ${SED} -E -e "s#(ARG MSFT_DOWNLOAD_SHA256)=.+#\1=${MSFT_DOWNLOAD_SHA256_AMD}#g" "$line"
-            ${SED} -E -e "s#(ARG SECURITY_VERSION)=.*#\1=${SECURITY_VERSION}#g" "$line"
         fi
     done

--- a/.github/updatecli.d/bump-go-release-version.sh
+++ b/.github/updatecli.d/bump-go-release-version.sh
@@ -24,9 +24,15 @@ GOLANG_DOWNLOAD_SHA256_ARM=$(curl -s -L https://golang.org/dl/\?mode\=json | jq 
 GOLANG_DOWNLOAD_SHA256_AMD=$(curl -s -L https://golang.org/dl/\?mode\=json | jq -r ".[] | select( .version | contains(\"go${GO_RELEASE_VERSION}\")) | .files[] | select (.filename | contains(\"go${GO_RELEASE_VERSION}.linux-amd64.tar.gz\")) | .sha256")
 
 # Gather microsoft/go sha256 values
-MSFT_DOWNLOAD_METADATA=$(curl -s -L https://aka.ms/golang/release/latest/go${GO_RELEASE_VERSION}.assets.json)
-MSFT_DOWNLOAD_SHA256_ARM=$(echo $MSFT_DOWNLOAD_METADATA | jq -r ".arches[] | select( .env.GOOS == \"linux\") | select( .env.GOARCH == \"arm64\") | .sha256")
-MSFT_DOWNLOAD_SHA256_AMD=$(echo $MSFT_DOWNLOAD_METADATA | jq -r ".arches[] | select( .env.GOOS == \"linux\") | select( .env.GOARCH == \"amd64\") | .sha256")
+URL=https://aka.ms/golang/release/latest/go${GO_RELEASE_VERSION}.assets.json
+if curl -s -L "$URL" > /dev/null ; then
+    MSFT_DOWNLOAD_METADATA=$(curl -s -L "$URL")
+    MSFT_DOWNLOAD_SHA256_ARM=$(echo $MSFT_DOWNLOAD_METADATA | jq -r ".arches[] | select( .env.GOOS == \"linux\") | select( .env.GOARCH == \"arm64\") | .sha256")
+    MSFT_DOWNLOAD_SHA256_AMD=$(echo $MSFT_DOWNLOAD_METADATA | jq -r ".arches[] | select( .env.GOOS == \"linux\") | select( .env.GOARCH == \"amd64\") | .sha256")
+    # when a new minor then we use `-1`
+    # then nex security versions will be `-2`, `-3`, etc, see bump-microsoft.yml
+    SECURITY_VERSION=-1
+fi
 
 ## As long as https://golang.org/dl/?mode=json supports only 2 major versions
 ## and there is a new major release, then it's required to parse https://golang.org/dl
@@ -46,9 +52,16 @@ find "go" -type f -name Dockerfile.tmpl -print0 |
         ${SED} -E -e "s#(ARG GOLANG_VERSION)=[0-9]+\.[0-9]+(\.[0-9]+)?#\1=${GO_RELEASE_VERSION}#g" "$line"
         if echo "$line" | grep -q 'arm' ; then
             ${SED} -E -e "s#(ARG GOLANG_DOWNLOAD_SHA256)=.+#\1=${GOLANG_DOWNLOAD_SHA256_ARM}#g" "$line"
-            ${SED} -E -e "s#(ARG MSFT_DOWNLOAD_SHA256)=.+#\1=${MSFT_DOWNLOAD_SHA256_ARM}#g" "$line"
+            if [ -n "$MSFT_DOWNLOAD_SHA256_ARM" ]; then
+                ${SED} -E -e "s#(ARG MSFT_DOWNLOAD_SHA256)=.+#\1=${MSFT_DOWNLOAD_SHA256_ARM}#g" "$line"
+            fi
         else
             ${SED} -E -e "s#(ARG GOLANG_DOWNLOAD_SHA256)=.+#\1=${GOLANG_DOWNLOAD_SHA256_AMD}#g" "$line"
-            ${SED} -E -e "s#(ARG MSFT_DOWNLOAD_SHA256)=.+#\1=${MSFT_DOWNLOAD_SHA256_AMD}#g" "$line"
+            if [ -n "$MSFT_DOWNLOAD_SHA256_AMD" ]; then
+                ${SED} -E -e "s#(ARG MSFT_DOWNLOAD_SHA256)=.+#\1=${MSFT_DOWNLOAD_SHA256_AMD}#g" "$line"
+            fi
+        fi
+        if [ -n "$SECURITY_VERSION" ]; then
+            ${SED} -E -e "s#(ARG SECURITY_VERSION)=.*#\1=${SECURITY_VERSION}#g" "$line"
         fi
     done

--- a/.github/updatecli.d/bump-golang.yml
+++ b/.github/updatecli.d/bump-golang.yml
@@ -82,13 +82,6 @@ conditions:
     spec:
       command: grep 'VERSION        := {{ source `latestGoVersion` }}' go/Makefile.common && exit 1 || exit 0
     failwhen: false
-  is-not-available:
-    name: Is assets.json available?
-    kind: file
-    disablesourceinput: true
-    spec:
-      file: https://aka.ms/golang/release/latest/go{{ source `latestGoVersion` }}.assets.json
-    failwhen: true
 
 targets:
   update-go-version:

--- a/.github/updatecli.d/bump-microsoft.yml
+++ b/.github/updatecli.d/bump-microsoft.yml
@@ -68,12 +68,22 @@ sources:
       command: echo {{ source "latestGoVersion" }}
 
 conditions:
-  is-already-updated:
+  is-security-already-updated:
     name: Is security version '{{ source "securityVersion" }}' not updated in 'go/base/Dockerfile.tmpl'?
     disablesourceinput: true
     kind: shell
     spec:
       command: grep 'ARG SECURITY_VERSION={{ source `securityVersion` }}' go/base/Dockerfile.tmpl && exit 1 || exit 0
+    failwhen: false
+
+  # as long as the same golang version then update the security version.
+  # if a new golang version then .github/updatecli.d/bump-golang.yml will be triggered.
+  is-golang-available:
+    name: Is version '{{ source "latestGoVersion" }}' available in 'go/base/Dockerfile.tmpl'?
+    disablesourceinput: true
+    kind: shell
+    spec:
+      command: grep 'ARG GOLANG_VERSION={{ source `latestGoVersion` }}' go/base/Dockerfile.tmpl && exit 0 || exit 1
     failwhen: false
 
 targets:

--- a/.github/updatecli.d/bump-microsoft.yml
+++ b/.github/updatecli.d/bump-microsoft.yml
@@ -67,6 +67,18 @@ sources:
     spec:
       command: echo {{ source "latestGoVersion" }}
 
+  golangVersion:
+    name: Get golang version
+    dependson:
+      - latestGoVersion
+    kind: shell
+    transformers:
+      - findsubmatch:
+          pattern: '^(\d+.\d+.\d+)-(\d+)'
+          captureindex: 1
+    spec:
+      command: echo {{ source "latestGoVersion" }}
+
 conditions:
   is-security-already-updated:
     name: Is security version '{{ source "securityVersion" }}' not updated in 'go/base/Dockerfile.tmpl'?
@@ -79,11 +91,11 @@ conditions:
   # as long as the same golang version then update the security version.
   # if a new golang version then .github/updatecli.d/bump-golang.yml will be triggered.
   is-golang-available:
-    name: Is version '{{ source "latestGoVersion" }}' available in 'go/base/Dockerfile.tmpl'?
+    name: Is version '{{ source "golangVersion" }}' available in 'go/base/Dockerfile.tmpl'?
     disablesourceinput: true
     kind: shell
     spec:
-      command: grep 'ARG GOLANG_VERSION={{ source `latestGoVersion` }}' go/base/Dockerfile.tmpl && exit 0 || exit 1
+      command: grep 'ARG GOLANG_VERSION={{ source `golangVersion` }}' go/base/Dockerfile.tmpl && exit 0 || exit 1
     failwhen: false
 
 targets:


### PR DESCRIPTION
### What

There are two updatecli pipelines:

1) For bumping the golang version (major.minor.patch approach)
2) For bumping the security version.

I still need to figure out how to avoid some issues we have with some errors when the PR exists. But for now I'll merge this PR
