### PR TITLE
bk: use GCP OIDC

### DIFF
--- a/.buildkite/fpm-pipeline.yml
+++ b/.buildkite/fpm-pipeline.yml
@@ -24,3 +24,10 @@ steps:
     agents:
       provider: "gcp"
       image: "${IMAGE_UBUNTU_X86_64}"
+    plugins:
+      # See https://github.com/elastic/oblt-infra/blob/main/conf/resources/repos/golang-crossbuild/01-gcp-buildkite-oidc.tf
+      # This plugin authenticates to Google Cloud using the OIDC token.
+      - elastic/oblt-google-auth#v1.3.0:
+          lifetime: 10800 # seconds
+          project-id: "elastic-observability-ci"
+          project-number: "911195782929"

--- a/.buildkite/llvm-apple-pipeline.yml
+++ b/.buildkite/llvm-apple-pipeline.yml
@@ -27,6 +27,13 @@ steps:
     agents:
       provider: "gcp"
       image: "${IMAGE_UBUNTU_X86_64}"
+    plugins:
+      # See https://github.com/elastic/oblt-infra/blob/main/conf/resources/repos/golang-crossbuild/01-gcp-buildkite-oidc.tf
+      # This plugin authenticates to Google Cloud using the OIDC token.
+      - elastic/oblt-google-auth#v1.3.0:
+          lifetime: 10800 # seconds
+          project-id: "elastic-observability-ci"
+          project-number: "911195782929"
     matrix:
       setup:
         debianVersion:
@@ -51,6 +58,13 @@ steps:
       provider: "aws"
       imagePrefix: "${IMAGE_UBUNTU_ARM_64}"
       instanceType: "t4g.large"
+    plugins:
+      # See https://github.com/elastic/oblt-infra/blob/main/conf/resources/repos/golang-crossbuild/01-gcp-buildkite-oidc.tf
+      # This plugin authenticates to Google Cloud using the OIDC token.
+      - elastic/oblt-google-auth#v1.3.0:
+          lifetime: 10800 # seconds
+          project-id: "elastic-observability-ci"
+          project-number: "911195782929"
     matrix:
       setup:
         debianVersion:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -30,6 +30,13 @@ steps:
           provider: "gcp"
           image: "${IMAGE_UBUNTU_X86_64}"
           instanceType: "${INSTANCE_TYPE_X86_64}"
+        plugins:
+          # See https://github.com/elastic/oblt-infra/blob/main/conf/resources/repos/golang-crossbuild/01-gcp-buildkite-oidc.tf
+          # This plugin authenticates to Google Cloud using the OIDC token.
+          - elastic/oblt-google-auth#v1.3.0:
+              lifetime: 10800 # seconds
+              project-id: "elastic-observability-ci"
+              project-number: "911195782929"
         retry:
           automatic:
             limit: 1
@@ -61,6 +68,13 @@ steps:
           provider: "aws"
           imagePrefix: "${IMAGE_UBUNTU_ARM_64}"
           instanceType: "t4g.large"
+        plugins:
+          # See https://github.com/elastic/oblt-infra/blob/main/conf/resources/repos/golang-crossbuild/01-gcp-buildkite-oidc.tf
+          # This plugin authenticates to Google Cloud using the OIDC token.
+          - elastic/oblt-google-auth#v1.3.0:
+              lifetime: 10800 # seconds
+              project-id: "elastic-observability-ci"
+              project-number: "911195782929"
         retry:
           automatic:
             limit: 1
@@ -92,6 +106,13 @@ steps:
           provider: "gcp"
           image: "${IMAGE_UBUNTU_X86_64}"
           instanceType: "${INSTANCE_TYPE_X86_64}"
+        plugins:
+          # See https://github.com/elastic/oblt-infra/blob/main/conf/resources/repos/golang-crossbuild/01-gcp-buildkite-oidc.tf
+          # This plugin authenticates to Google Cloud using the OIDC token.
+          - elastic/oblt-google-auth#v1.3.0:
+              lifetime: 10800 # seconds
+              project-id: "elastic-observability-ci"
+              project-number: "911195782929"
         retry:
           automatic:
             limit: 1
@@ -123,6 +144,13 @@ steps:
           provider: "aws"
           imagePrefix: "${IMAGE_UBUNTU_ARM_64}"
           instanceType: "t4g.large"
+        plugins:
+          # See https://github.com/elastic/oblt-infra/blob/main/conf/resources/repos/golang-crossbuild/01-gcp-buildkite-oidc.tf
+          # This plugin authenticates to Google Cloud using the OIDC token.
+          - elastic/oblt-google-auth#v1.3.0:
+              lifetime: 10800 # seconds
+              project-id: "elastic-observability-ci"
+              project-number: "911195782929"
         retry:
           automatic:
             limit: 1

--- a/.buildkite/scripts/build.sh
+++ b/.buildkite/scripts/build.sh
@@ -13,7 +13,7 @@ with_go "${GOLANG_VERSION}"
 with_mage
 google_cloud_auth
 
-make -C go -f "${MAKEFILE}" build"${is_arm}" GS_BUCKET_PATH=ingest-buildkite-ci
+make -C go -f "${MAKEFILE}" build"${is_arm}" GS_BUCKET_PATH=golang-crossbuild-ci-internal
 echo ":: List Docker images staging ::"
 docker images --format "table {{.Repository}}:{{.Tag}}\t{{.Size}}" --filter=reference="${STAGING_IMAGE}/golang-crossbuild"
 

--- a/.buildkite/scripts/llvm-apple/build.sh
+++ b/.buildkite/scripts/llvm-apple/build.sh
@@ -16,5 +16,5 @@ add_bin_path
 with_go "${GOLANG_VERSION}"
 with_mage
 
-retry 3 make -C "${makefile}" build GS_BUCKET_PATH=ingest-buildkite-ci
+retry 3 make -C "${makefile}" build GS_BUCKET_PATH=golang-crossbuild-ci-internal
 docker images --format "table {{.Repository}}:{{.Tag}}\t{{.Size}}" --filter=reference="${docker_filter_ref}"

--- a/.buildkite/scripts/llvm-fpm/build_and_publish.sh
+++ b/.buildkite/scripts/llvm-fpm/build_and_publish.sh
@@ -16,5 +16,5 @@ add_bin_path
 with_go "${GOLANG_VERSION}"
 with_mage
 
-retry 3 make -C "${makefile}" build GS_BUCKET_PATH=ingest-buildkite-ci
+retry 3 make -C "${makefile}" build GS_BUCKET_PATH=golang-crossbuild-ci-internal
 docker images --format "table {{.Repository}}:{{.Tag}}\t{{.Size}}" --filter=reference="${docker_filter_ref}"

--- a/Makefile.common
+++ b/Makefile.common
@@ -7,12 +7,12 @@ NPCAP_VERSION := 1.80
 NPCAP_FILE    := npcap-$(NPCAP_VERSION)-oem.exe
 SUFFIX_NPCAP_VERSION := -npcap-$(NPCAP_VERSION)
 NPCAP_REPOSITORY := docker.elastic.co/observability-ci
-GS_BUCKET_PATH ?= ingest-buildkite-ci
+GS_BUCKET_PATH ?= golang-crossbuild-ci-internal
 
 # Requires login at google storage.
 copy-npcap:
 ifeq ($(CI),true)
-	@gsutil cp gs://$(GS_BUCKET_PATH)/private/$(NPCAP_FILE) ../npcap/lib/$(NPCAP_FILE)
+	@gcloud storage cp gs://$(GS_BUCKET_PATH)/private/$(NPCAP_FILE) ../npcap/lib/$(NPCAP_FILE)
 else
 	@echo 'Only available if running in the CI'
 endif
@@ -20,7 +20,7 @@ endif
 # Requires login at google storage.
 copy-sdks:
 ifeq ($(CI),true)
-	@gcloud storage cp gs://ingest-buildkite-ci/sdks . --recursive
+	@gcloud storage cp gs://$(GS_BUCKET_PATH)/sdks . --recursive
 else
 	@echo 'Only available if running in the CI'
 endif

--- a/NPCAP.md
+++ b/NPCAP.md
@@ -5,8 +5,8 @@ If you'd like to bump the npcap version please follow the below steps:
 1) Update `NPCAP_VERSION` value in the `Makefile`.
   * **NOTE**: Make sure the PR adding this is back-ported to the Go versions required by the Packetbeat CrossBuild target in [the mage file](https://github.com/elastic/beats/blob/main/x-pack/packetbeat/magefile.go). This is specified in the beats `.go-version` file.
 2) Download the new artifact.
-3) Upload the artifact to `gs://ingest-buildkite-ci/private`.
-  * **NOTE**: This particular Google Bucket can be accessible only by Elasticians who have got access to the Google project called `elastic-platform-ingest`.
+3) Upload the artifact to `gs://golang-crossbuild-ci-internal/private`.
+  * **NOTE**: This particular Google Bucket can be accessible only by Elasticians who have got access to the Google project called `elastic-observability-ci`. It's managed thorugh some Terraform code.
 
 Credentials to the artifact service can be found in the `APM-Shared` folder in the password management tool.
 

--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ It was added to golang-crossbuild due limitations of the build system.
 The `main` image is the base image for the `amd64` architecture, it is build for Debian 7+.
 It is used to cross compile for `linux/amd`, `linux/amd64`, `win/amd`, and `win/amd64`.
 This Docker immage add two libraries to the `base` image, `libpcap` and `WpdPack` to be able to capture network packages on diferent OS.
-Thes two libraries are precompiled and stored at https://storage.googleapis.com/ingest-buildkite-ci/sdks.
+Thes two libraries are precompiled and stored at https://storage.googleapis.com/golang-crossbuild-ci-internal/sdks.
 
 ## go/darwin Docker image
 
@@ -387,5 +387,5 @@ XCODEDIR=osxcross/build/tmp_<X> ./tools/gen_sdk_package.sh
 The SDK should be in the working directory.
 The tmp dir can be safely deleted after this.
 
-The SDKs should be uploaded into the `gs://ingest-buildkite-ci/sdks` bucket on GCP (Google Cloud Platform).
-This is accessible to authorized users in the `platform-ingest` project [here](https://console.cloud.google.com/storage/browser/ingest-buildkite-ci/sdks).
+The SDKs should be uploaded into the `gs://golang-crossbuild-ci-internal/sdks` bucket on GCP (Google Cloud Platform).
+This is accessible to authorized users in the `elastic-observability-ci` project [here](https://console.cloud.google.com/storage/browser/golang-crossbuild-ci-internal/sdks).


### PR DESCRIPTION
IIUC, BK could access the former bucket since the VM were already configured with the google credentials.

In this case, I'm changing to use OIDC for GCP and being explicit about what the BK pipelines can access to.

It requires changes in the infra part 