### PR TITLE
Revert "stop publishing debian7 and debian8 from 1.23.7 onwards (#510)"

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -37,6 +37,8 @@ steps:
           setup:
             makefile:
               - "Makefile"
+              - "Makefile.debian7"
+              - "Makefile.debian8"
               - "Makefile.debian9"
               - "Makefile.debian10"
               - "Makefile.debian11"
@@ -99,6 +101,8 @@ steps:
           setup:
             makefile:
               - "Makefile"
+              - "Makefile.debian7"
+              - "Makefile.debian8"
               - "Makefile.debian9"
               - "Makefile.debian10"
               - "Makefile.debian11"

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -48,6 +48,8 @@ template: |
   - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-base`
   - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-darwin` - darwin/amd64 (MacOS 10.11, MacOS 10.14)
   - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-main` - linux/i386, linux/amd64, windows/amd64
+  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-main-debian7` - linux/i386, linux/amd64, windows/amd64
+  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-main-debian8` - linux/i386, linux/amd64, windows/amd64
   - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-main-debian9` - linux/i386, linux/amd64, windows/amd64
   - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-main-debian10` - linux/i386, linux/amd64, windows/amd64
   - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-main-debian11` - linux/i386, linux/amd64, windows/amd64

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,8 @@ build:
 	@echo '0' > ${status}
 	@$(foreach var,$(TARGETS), \
 		$(MAKE) -C $(var) $@ || echo '1' > ${status}; \
+		$(MAKE) -C $(var) -f Makefile.debian7 $@ || echo '1' > ${status}; \
+		$(MAKE) -C $(var) -f Makefile.debian8 $@ || echo '1' > ${status}; \
 		$(MAKE) -C $(var) -f Makefile.debian9 $@ || echo '1' > ${status}; \
 		$(MAKE) -C $(var) -f Makefile.debian10 $@ || echo '1' > ${status}; \
 		$(MAKE) -C $(var) -f Makefile.debian11 $@ || echo '1' > ${status}; \
@@ -31,6 +33,8 @@ push:
 	@echo '0' > ${status}
 	@$(foreach var,$(TARGETS), \
 		$(MAKE) -C $(var) $@ || echo '1' > ${status}; \
+		$(MAKE) -C $(var) -f Makefile.debian7 $@ || echo '1' > ${status}; \
+		$(MAKE) -C $(var) -f Makefile.debian8 $@ || echo '1' > ${status}; \
 		$(MAKE) -C $(var) -f Makefile.debian9 $@ || echo '1' > ${status}; \
 		$(MAKE) -C $(var) -f Makefile.debian10 $@ || echo '1' > ${status}; \
 		$(MAKE) -C $(var) -f Makefile.debian11 $@ || echo '1' > ${status}; \

--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ it triggers the build of all Docker images for all architectures and Debian vers
 The file `go/Makefile.common` is the default Makefile used to build the Docker images for the different architectures.
 There is additional Makefile for each Debian version that is used to build the Docker images for that Debian version.
 
+* `go/Makefile.debian7`
+* `go/Makefile.debian8`
 * `go/Makefile.debian9`
 * `go/Makefile.debian10`
 * `go/Makefile.debian11`

--- a/go/Makefile.debian7
+++ b/go/Makefile.debian7
@@ -1,0 +1,14 @@
+IMAGES         := base main
+DEBIAN_VERSION := 7
+TAG_EXTENSION  := -debian7
+
+export DEBIAN_VERSION TAG_EXTENSION
+
+build:
+	@$(foreach var,$(IMAGES),$(MAKE) -C $(var) build || exit 1;)
+
+# Requires login at https://docker.elastic.co:7000/.
+push:
+	@$(foreach var,$(IMAGES),$(MAKE) -C $(var) push || exit 1;)
+
+.PHONY: build push

--- a/go/Makefile.debian8
+++ b/go/Makefile.debian8
@@ -1,0 +1,15 @@
+IMAGES         := base main darwin npcap
+DEBIAN_VERSION := 8
+TAG_EXTENSION  := -debian8
+
+export DEBIAN_VERSION TAG_EXTENSION
+
+build:
+	export |grep TAG_EXTENSION
+	@$(foreach var,$(IMAGES),$(MAKE) -C $(var) build || exit 1;)
+
+# Requires login at https://docker.elastic.co:7000/.
+push:
+	@$(foreach var,$(IMAGES),$(MAKE) -C $(var) push || exit 1;)
+
+.PHONY: build push


### PR DESCRIPTION
Notifies https://github.com/elastic/apm-server/pull/16849

So we can release `7.17` that still uses `debian-7`:
- https://github.com/elastic/beats/blob/a156701b0302ca0e4e8676d2de96ebf2c1b7879d/dev-tools/mage/crossbuild.go#L222-L225