### PR TITLE
Restore debian7 images needed for beats 7.17

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -117,6 +117,7 @@ steps:
           setup:
             makefile:
               - "Makefile"
+              - "Makefile.debian7"
               - "Makefile.debian9"
               - "Makefile.debian10"
               - "Makefile.debian11"
@@ -183,6 +184,7 @@ steps:
           setup:
             makefile:
               - "Makefile"
+              - "Makefile.debian7"
               - "Makefile.debian9"
               - "Makefile.debian10"
               - "Makefile.debian11"

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -48,6 +48,7 @@ template: |
   - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-base`
   - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-darwin` - darwin/amd64 (MacOS 10.11, MacOS 10.14)
   - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-main` - linux/i386, linux/amd64, windows/amd64
+  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-main-debian7` - linux/i386, linux/amd64, windows/amd64
   - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-main-debian9` - linux/i386, linux/amd64, windows/amd64
   - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-main-debian10` - linux/i386, linux/amd64, windows/amd64
   - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-main-debian11` - linux/i386, linux/amd64, windows/amd64

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ build:
 	@echo '0' > ${status}
 	@$(foreach var,$(TARGETS), \
 		$(MAKE) -C $(var) $@ || echo '1' > ${status}; \
+		$(MAKE) -C $(var) -f Makefile.debian7 $@ || echo '1' > ${status}; \
 		$(MAKE) -C $(var) -f Makefile.debian9 $@ || echo '1' > ${status}; \
 		$(MAKE) -C $(var) -f Makefile.debian10 $@ || echo '1' > ${status}; \
 		$(MAKE) -C $(var) -f Makefile.debian11 $@ || echo '1' > ${status}; \
@@ -31,6 +32,7 @@ push:
 	@echo '0' > ${status}
 	@$(foreach var,$(TARGETS), \
 		$(MAKE) -C $(var) $@ || echo '1' > ${status}; \
+		$(MAKE) -C $(var) -f Makefile.debian7 $@ || echo '1' > ${status}; \
 		$(MAKE) -C $(var) -f Makefile.debian9 $@ || echo '1' > ${status}; \
 		$(MAKE) -C $(var) -f Makefile.debian10 $@ || echo '1' > ${status}; \
 		$(MAKE) -C $(var) -f Makefile.debian11 $@ || echo '1' > ${status}; \

--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ Replace `<GOLANG_VERSION>` with the version you would like to use, for instance:
 - `docker.elastic.co/beats-dev/golang-crossbuild:<GOLANG_VERSION>-darwin` - darwin/amd64 (MacOS 10.11, MacOS 10.14)
 - `docker.elastic.co/beats-dev/golang-crossbuild:<GOLANG_VERSION>-main` - linux/i386, linux/amd64, windows/amd64
 - `docker.elastic.co/beats-dev/golang-crossbuild:<GOLANG_VERSION>-main-debian7` - linux/i386, linux/amd64, windows/amd64
-- `docker.elastic.co/beats-dev/golang-crossbuild:<GOLANG_VERSION>-main-debian8` - linux/i386, linux/amd64, windows/amd64
 - `docker.elastic.co/beats-dev/golang-crossbuild:<GOLANG_VERSION>-main-debian9` - linux/i386, linux/amd64, windows/amd64
 - `docker.elastic.co/beats-dev/golang-crossbuild:<GOLANG_VERSION>-main-debian10` - linux/i386, linux/amd64, windows/amd64
 - `docker.elastic.co/beats-dev/golang-crossbuild:<GOLANG_VERSION>-main-debian11` - linux/i386, linux/amd64, windows/amd64
@@ -74,7 +73,6 @@ Replace `<GOLANG_VERSION>` with the version you would like to use, for instance:
 ### glibc
 
 * **Debian7** uses `glibc 2.13` so the resulting binaries (if dynamically linked) have greater compatibility.
-* **Debian8** uses `glibc 2.19`.
 * **Debian9** uses `glibc 2.24`.
 * **Debian10** uses `glibc 2.28`.
 * **Debian11** uses `glibc 2.31`.
@@ -119,6 +117,7 @@ it triggers the build of all Docker images for all architectures and Debian vers
 The file `go/Makefile.common` is the default Makefile used to build the Docker images for the different architectures.
 There is additional Makefile for each Debian version that is used to build the Docker images for that Debian version.
 
+* `go/Makefile.debian7`
 * `go/Makefile.debian9`
 * `go/Makefile.debian10`
 * `go/Makefile.debian11`

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Replace `<GOLANG_VERSION>` with the version you would like to use, for instance:
 - `docker.elastic.co/beats-dev/golang-crossbuild:<GOLANG_VERSION>-darwin` - darwin/amd64 (MacOS 10.11, MacOS 10.14)
 - `docker.elastic.co/beats-dev/golang-crossbuild:<GOLANG_VERSION>-main` - linux/i386, linux/amd64, windows/amd64
 - `docker.elastic.co/beats-dev/golang-crossbuild:<GOLANG_VERSION>-main-debian7` - linux/i386, linux/amd64, windows/amd64
+- `docker.elastic.co/beats-dev/golang-crossbuild:<GOLANG_VERSION>-main-debian8` - linux/i386, linux/amd64, windows/amd64
 - `docker.elastic.co/beats-dev/golang-crossbuild:<GOLANG_VERSION>-main-debian9` - linux/i386, linux/amd64, windows/amd64
 - `docker.elastic.co/beats-dev/golang-crossbuild:<GOLANG_VERSION>-main-debian10` - linux/i386, linux/amd64, windows/amd64
 - `docker.elastic.co/beats-dev/golang-crossbuild:<GOLANG_VERSION>-main-debian11` - linux/i386, linux/amd64, windows/amd64
@@ -73,6 +74,7 @@ Replace `<GOLANG_VERSION>` with the version you would like to use, for instance:
 ### glibc
 
 * **Debian7** uses `glibc 2.13` so the resulting binaries (if dynamically linked) have greater compatibility.
+* **Debian8** uses `glibc 2.19`.
 * **Debian9** uses `glibc 2.24`.
 * **Debian10** uses `glibc 2.28`.
 * **Debian11** uses `glibc 2.31`.

--- a/go/Makefile.debian7
+++ b/go/Makefile.debian7
@@ -1,0 +1,14 @@
+IMAGES         := base main
+DEBIAN_VERSION := 7
+TAG_EXTENSION  := -debian7
+
+export DEBIAN_VERSION TAG_EXTENSION
+
+build:
+	@$(foreach var,$(IMAGES),$(MAKE) -C $(var) build || exit 1;)
+
+# Requires login at https://docker.elastic.co:7000/.
+push:
+	@$(foreach var,$(IMAGES),$(MAKE) -C $(var) push || exit 1;)
+
+.PHONY: build push


### PR DESCRIPTION
Beats 7.17 has no further planned releases, but we must remain ready for potential emergency patches.

Given this policy, we also aim to keep up with newer Go versions. PR #510 removed debian7 and debian8 images, causing failures when we upgraded 7.17 to go1.24.3. We cannot migrate to debian 9-11 due to glibc 2.13 constraints.

That said, restore the debian7 images to fix our 7.17 builds.

Relates https://github.com/elastic/beats/pull/43984.