### PR TITLE
bk: avoid running llvm-apple if changes in the main pipeline.yml

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -67,7 +67,8 @@ steps:
               interpolation: false
               watch:
                 - path:
-                    - .buildkite/pipeline.yml
+                    # As long as https://github.com/elastic/golang-crossbuild/issues/615
+                    #- .buildkite/pipeline.yml
                     - .buildkite/llvm-apple-pipeline.yml
                     - .buildkite/scripts/llvm-apple
                     - go/llvm-apple/**


### PR DESCRIPTION
As long as https://github.com/elastic/golang-crossbuild/issues/615 , LLVM Apple build fails.

It's not an artifact we need to generate - in fact it has not been generated for > 1 year or so