### PR TITLE
validate installed golang version and honour VERSION build-args

### DIFF
--- a/.github/updatecli.d/bump-go-release-version.sh
+++ b/.github/updatecli.d/bump-go-release-version.sh
@@ -49,7 +49,6 @@ echo "Update go version ${GO_RELEASE_VERSION}"
 
 find "go" -type f -name Dockerfile.tmpl -print0 |
     while IFS= read -r -d '' line; do
-        ${SED} -E -e "s#(ARG GOLANG_VERSION)=[0-9]+\.[0-9]+(\.[0-9]+)?#\1=${GO_RELEASE_VERSION}#g" "$line"
         if echo "$line" | grep -q 'arm' ; then
             ${SED} -E -e "s#(ARG GOLANG_DOWNLOAD_SHA256)=.+#\1=${GOLANG_DOWNLOAD_SHA256_ARM}#g" "$line"
             if [ -n "$MSFT_DOWNLOAD_SHA256_ARM" ]; then

--- a/.github/updatecli.d/bump-microsoft.yml
+++ b/.github/updatecli.d/bump-microsoft.yml
@@ -88,16 +88,6 @@ conditions:
       command: grep 'ARG SECURITY_VERSION={{ source `securityVersion` }}' go/base/Dockerfile.tmpl && exit 1 || exit 0
     failwhen: false
 
-  # as long as the same golang version then update the security version.
-  # if a new golang version then .github/updatecli.d/bump-golang.yml will be triggered.
-  is-golang-available:
-    name: Is version '{{ source "golangVersion" }}' available in 'go/base/Dockerfile.tmpl'?
-    disablesourceinput: true
-    kind: shell
-    spec:
-      command: grep 'ARG GOLANG_VERSION={{ source `golangVersion` }}' go/base/Dockerfile.tmpl && exit 0 || exit 1
-    failwhen: false
-
 targets:
   update-go-versions:
     name: 'Update go version {{ source "latestGoVersion" }}'

--- a/go/base-arm/Dockerfile.tmpl
+++ b/go/base-arm/Dockerfile.tmpl
@@ -57,15 +57,15 @@ RUN \
             libsqlite3-0 \
         && rm -rf /var/lib/apt/lists/*
 
-ARG GOLANG_VERSION=1.24.3
+ARG VERSION
 {{- if eq .FIPS "true"}}
 ARG SECURITY_VERSION=-1
-ARG GOLANG_DOWNLOAD_URL=https://aka.ms/golang/release/latest/go$GOLANG_VERSION$SECURITY_VERSION.linux-arm64.tar.gz
+ARG GOLANG_DOWNLOAD_URL=https://aka.ms/golang/release/latest/go$VERSION$SECURITY_VERSION.linux-arm64.tar.gz
 # Use a different arg name for microsoft/go sha so it can be handled seperately from the regular golang sha
 ARG MSFT_DOWNLOAD_SHA256=6d4232da7ca7d2bd19e0b6b69524448de8e5480f49e5d39f7a5507cef682a9ea
 ARG DOWNLOAD_SHA256=$MSFT_DOWNLOAD_SHA256
 {{- else}}
-ARG GOLANG_DOWNLOAD_URL=https://golang.org/dl/go$GOLANG_VERSION.linux-arm64.tar.gz
+ARG GOLANG_DOWNLOAD_URL=https://golang.org/dl/go$VERSION.linux-arm64.tar.gz
 ARG GOLANG_DOWNLOAD_SHA256=a463cb59382bd7ae7d8f4c68846e73c4d589f223c589ac76871b66811ded7836
 ARG DOWNLOAD_SHA256=$GOLANG_DOWNLOAD_SHA256
 {{- end}}
@@ -82,6 +82,10 @@ ENV PATH $PATH:/usr/local/go/bin
 RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
 WORKDIR $GOPATH
 
+# Validate the Go installation
+RUN go version \
+    && go version | grep "go${VERSION}" || (echo "Go version mismatch: expected to contain go${VERSION}" && exit 1)
+
 COPY rootfs /
 
 # show the GLIBC version
@@ -91,7 +95,7 @@ WORKDIR /
 
 RUN mkdir -p /root/.config/go/telemetry && echo "off 2024-08-23" > /root/.config/go/telemetry/mode
 ENV GOTOOLCHAIN local
-RUN go mod init github.com/elastic/golang-crossbuild-$GOLANG_VERSION-arm \
+RUN go mod init github.com/elastic/golang-crossbuild-$VERSION-arm \
     && go get . \
     && go env \
     && echo "toolcompile=$(go tool compile -V)" \

--- a/go/base/Dockerfile.tmpl
+++ b/go/base/Dockerfile.tmpl
@@ -31,15 +31,15 @@ RUN apt-get -o Acquire::Check-Valid-Until=false update -y --no-install-recommend
 RUN ln -s /usr/bin/pip3 /usr/bin/pip
 {{- end }}
 
-ARG GOLANG_VERSION=1.24.3
+ARG VERSION
 {{- if eq .FIPS "true"}}
 ARG SECURITY_VERSION=-1
-ARG GOLANG_DOWNLOAD_URL=https://aka.ms/golang/release/latest/go$GOLANG_VERSION$SECURITY_VERSION.linux-amd64.tar.gz
+ARG GOLANG_DOWNLOAD_URL=https://aka.ms/golang/release/latest/go$VERSION$SECURITY_VERSION.linux-amd64.tar.gz
 # Use a different arg name for microsoft/go sha so it can be handled seperately from the regular golang sha
 ARG MSFT_DOWNLOAD_SHA256=d1e9e4465951816b556f648dfebc1cf20fdef4832d7d3f01f1ef35a259375286
 ARG DOWNLOAD_SHA256=$MSFT_DOWNLOAD_SHA256
 {{- else}}
-ARG GOLANG_DOWNLOAD_URL=https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
+ARG GOLANG_DOWNLOAD_URL=https://golang.org/dl/go$VERSION.linux-amd64.tar.gz
 ARG GOLANG_DOWNLOAD_SHA256=3333f6ea53afa971e9078895eaa4ac7204a8c6b5c68c10e6bc9a33e8e391bdd8
 ARG DOWNLOAD_SHA256=$GOLANG_DOWNLOAD_SHA256
 {{- end }}
@@ -56,6 +56,10 @@ ENV PATH $PATH:/usr/local/go/bin
 RUN mkdir -p "$GOPATH/src" "$GOPATH/bin" && chmod -R 777 "$GOPATH"
 WORKDIR $GOPATH
 
+# Validate the Go installation
+RUN go version \
+    && go version | grep "go${VERSION}" || (echo "Go version mismatch: expected to contain go${VERSION}" && exit 1)
+
 COPY rootfs /
 
 # show the GLIBC version
@@ -64,7 +68,7 @@ RUN ldd --version
 WORKDIR /
 RUN mkdir -p /root/.config/go/telemetry && echo "off 2024-08-23" > /root/.config/go/telemetry/mode
 ENV GOTOOLCHAIN=local
-RUN go mod init github.com/elastic/golang-crossbuild-$GOLANG_VERSION \
+RUN go mod init github.com/elastic/golang-crossbuild-$VERSION \
     && go get . \
     && go env \
     && echo "toolcompile=$(go tool compile -V)" \


### PR DESCRIPTION
`VERSION` build arg are managed through https://github.com/elastic/golang-crossbuild/blob/main/go/Makefile.common#L5
Add `go version` assertion so we know if the container image has been actually produced with the correct version. See https://github.com/elastic/golang-crossbuild/pull/623#issuecomment-2951941844
Simplify the updatecli to use VERSION rather than GOLANG_VERSION.

### Why

Help with detecting breaking changes when a bump PR is partially updated. 

Still to figure out what's going on.


