### PR TITLE
fix: 1.24.4

### DIFF
--- a/go/base-arm/Dockerfile.tmpl
+++ b/go/base-arm/Dockerfile.tmpl
@@ -57,16 +57,16 @@ RUN \
             libsqlite3-0 \
         && rm -rf /var/lib/apt/lists/*
 
-ARG GOLANG_VERSION=1.24.3
+ARG GOLANG_VERSION=1.24.4
 {{- if eq .FIPS "true"}}
 ARG SECURITY_VERSION=-1
 ARG GOLANG_DOWNLOAD_URL=https://aka.ms/golang/release/latest/go$GOLANG_VERSION$SECURITY_VERSION.linux-arm64.tar.gz
 # Use a different arg name for microsoft/go sha so it can be handled seperately from the regular golang sha
-ARG MSFT_DOWNLOAD_SHA256=6d4232da7ca7d2bd19e0b6b69524448de8e5480f49e5d39f7a5507cef682a9ea
+ARG MSFT_DOWNLOAD_SHA256=44b769dd398f8fc5f381812c2eb323b4bc6cb11010d59efdba3244184e29b3fd
 ARG DOWNLOAD_SHA256=$MSFT_DOWNLOAD_SHA256
 {{- else}}
 ARG GOLANG_DOWNLOAD_URL=https://golang.org/dl/go$GOLANG_VERSION.linux-arm64.tar.gz
-ARG GOLANG_DOWNLOAD_SHA256=a463cb59382bd7ae7d8f4c68846e73c4d589f223c589ac76871b66811ded7836
+ARG GOLANG_DOWNLOAD_SHA256=d5501ee5aca0f258d5fe9bfaed401958445014495dc115f202d43d5210b45241
 ARG DOWNLOAD_SHA256=$GOLANG_DOWNLOAD_SHA256
 {{- end}}
 

--- a/go/base/Dockerfile.tmpl
+++ b/go/base/Dockerfile.tmpl
@@ -31,16 +31,16 @@ RUN apt-get -o Acquire::Check-Valid-Until=false update -y --no-install-recommend
 RUN ln -s /usr/bin/pip3 /usr/bin/pip
 {{- end }}
 
-ARG GOLANG_VERSION=1.24.3
+ARG GOLANG_VERSION=1.24.4
 {{- if eq .FIPS "true"}}
 ARG SECURITY_VERSION=-1
 ARG GOLANG_DOWNLOAD_URL=https://aka.ms/golang/release/latest/go$GOLANG_VERSION$SECURITY_VERSION.linux-amd64.tar.gz
 # Use a different arg name for microsoft/go sha so it can be handled seperately from the regular golang sha
-ARG MSFT_DOWNLOAD_SHA256=d1e9e4465951816b556f648dfebc1cf20fdef4832d7d3f01f1ef35a259375286
+ARG MSFT_DOWNLOAD_SHA256=f21ddf7c3b029cf67615f6b2ca68e5aa83a50b2e2ea5952a5ea7bf9fa17e3358
 ARG DOWNLOAD_SHA256=$MSFT_DOWNLOAD_SHA256
 {{- else}}
 ARG GOLANG_DOWNLOAD_URL=https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz
-ARG GOLANG_DOWNLOAD_SHA256=3333f6ea53afa971e9078895eaa4ac7204a8c6b5c68c10e6bc9a33e8e391bdd8
+ARG GOLANG_DOWNLOAD_SHA256=77e5da33bb72aeaef1ba4418b6fe511bc4d041873cbf82e5aa6318740df98717
 ARG DOWNLOAD_SHA256=$GOLANG_DOWNLOAD_SHA256
 {{- end }}
 


### PR DESCRIPTION
See https://github.com/elastic/golang-crossbuild/pull/623#issuecomment-2951941844


```bash
$ .github/updatecli.d/bump-go-release-version.sh 1.24.4  
Update go version 1.24.4
$ .github/updatecli.d/bump-go-microsoft-version.sh 1.24.4-1
Update go version 1.24.4-1
```