### PR TITLE
docs: update the list of containers

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -33,29 +33,39 @@ version-resolver:
 template: |
   ## Go $RESOLVED_VERSION
 
-  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-arm` - linux/arm64
-  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-arm-debian9` - linux/armv5, linux/armv6
-  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-arm-debian10` - linux/armv5, linux/armv6
-  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-arm-debian11` - linux/armv5, linux/armv6
-  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-arm-debian12` - linux/armv5, linux/armv6
-  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-armel` - linux/armv5, linux/armv6
-  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-armel-debian12` - linux/armv5, linux/armv6
-  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-armhf` - linux/armv7
-  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-armhf-debian9` - linux/armv7
-  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-armhf-debian10` - linux/armv7
-  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-armhf-debian11` - linux/armv7
-  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-armhf-debian12` - linux/armv7
-  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-base`
-  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-darwin` - darwin/amd64 (MacOS 10.11, MacOS 10.14)
-  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-main` - linux/i386, linux/amd64, windows/amd64
-  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-main-debian7` - linux/i386, linux/amd64, windows/amd64
-  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-main-debian9` - linux/i386, linux/amd64, windows/amd64
-  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-main-debian10` - linux/i386, linux/amd64, windows/amd64
-  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-main-debian11` - linux/i386, linux/amd64, windows/amd64
-  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-main-debian12` - linux/i386, linux/amd64, windows/amd64
-  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-mips-debian12` - linux/mips64, linux/mips64el
-  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-ppc-debian12` - linux/ppc64, linux/ppc64le
-  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-s390x-debian12` - linux/s390x
+  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-armel-debian12(-fips)?`    - linux/armv5, linux/armv6
+  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-armhf-debian9(-fips)?`     - linux/armv7
+  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-armhf-debian10(-fips)?`    - linux/armv7
+  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-armhf-debian11(-fips)?`    - linux/armv7
+  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-armhf-debian12(-fips)?`    - linux/armv7
+  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-armhf(-fips)?`             - linux/armv7
+  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-base-arm-debian9(-fips)?`  - linux/arm64
+  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-base-arm-debian10(-fips)?` - linux/arm64
+  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-base-arm-debian11(-fips)?` - linux/arm64
+  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-base-arm-debian12(-fips)?` - linux/arm64
+  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-base-debian7(-fips)?`
+  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-base-debian9(-fips)?`
+  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-base-debian10(-fips)?`
+  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-base-debian11(-fips)?`
+  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-base-debian12(-fips)?`
+  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-base(-fips)?`
+  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-darwin-arm64-debian10(-fips)?` - darwin/arm64 (MacOS 10.11, MacOS 10.14)
+  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-darwin-arm64-debian11(-fips)?` - darwin/arm64 (MacOS 10.11, MacOS 10.14)
+  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-darwin-arm64-debian12(-fips)?` - darwin/arm64 (MacOS 10.11, MacOS 10.14)
+  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-darwin-debian9(-fips)?`  - darwin/amd64 (MacOS 10.11, MacOS 10.14)
+  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-darwin-debian10(-fips)?` - darwin/amd64 (MacOS 10.11, MacOS 10.14)
+  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-darwin-debian11(-fips)?` - darwin/amd64 (MacOS 10.11, MacOS 10.14)
+  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-darwin-debian12(-fips)?` - darwin/amd64 (MacOS 10.11, MacOS 10.14)
+  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-darwin(-fips)?`          - darwin/amd64 (MacOS 10.11, MacOS 10.14)
+  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-main-debian7(-fips)?`    - linux/i386, linux/amd64, windows/amd64
+  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-main-debian9(-fips)?`    - linux/i386, linux/amd64, windows/amd64
+  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-main-debian10(-fips)?`   - linux/i386, linux/amd64, windows/amd64
+  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-main-debian11(-fips)?`   - linux/i386, linux/amd64, windows/amd64
+  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-main-debian12(-fips)?`   - linux/i386, linux/amd64, windows/amd64
+  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-main(-fips)?`            - linux/i386, linux/amd64, windows/amd64
+  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-mips-debian12(-fips)?`   - linux/mips64, linux/mips64el
+  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-ppc-debian12(-fips)?`    - linux/ppc64, linux/ppc64le
+  - `docker.elastic.co/beats-dev/golang-crossbuild:$RESOLVED_VERSION-s390x-debian12(-fips)?`  - linux/s390x
 
   ### Changes
 


### PR DESCRIPTION
I ran 

```bash
$ crane ls  docker.elastic.co/beats-dev/golang-crossbuild 
 | grep 1.24.4
1.24.4-armel-debian12-fips
1.24.4-armel-debian12
1.24.4-armhf-debian10-fips
1.24.4-armhf-debian10
1.24.4-armhf-debian11-fips
1.24.4-armhf-debian11
1.24.4-armhf-debian12-fips
1.24.4-armhf-debian12
1.24.4-armhf-debian9-fips
1.24.4-armhf-debian9
1.24.4-armhf-fips
1.24.4-armhf
1.24.4-base-arm-debian10-fips
1.24.4-base-arm-debian10
1.24.4-base-arm-debian11-fips
1.24.4-base-arm-debian11
1.24.4-base-arm-debian12-fips
1.24.4-base-arm-debian12
1.24.4-base-arm-debian9-fips
1.24.4-base-arm-debian9
1.24.4-base-debian10-fips
1.24.4-base-debian10
1.24.4-base-debian11-fips
1.24.4-base-debian11
1.24.4-base-debian12-fips
1.24.4-base-debian12
1.24.4-base-debian7-fips
1.24.4-base-debian7
1.24.4-base-debian9-fips
1.24.4-base-debian9
1.24.4-base-fips
1.24.4-base
1.24.4-darwin-arm64-debian10-fips
1.24.4-darwin-arm64-debian10
1.24.4-darwin-arm64-debian11-fips
1.24.4-darwin-arm64-debian11
1.24.4-darwin-arm64-debian12-fips
1.24.4-darwin-arm64-debian12
1.24.4-darwin-debian10-fips
1.24.4-darwin-debian10
1.24.4-darwin-debian11-fips
1.24.4-darwin-debian11
1.24.4-darwin-debian12-fips
1.24.4-darwin-debian12
1.24.4-darwin-debian9-fips
1.24.4-darwin-debian9
1.24.4-darwin-fips
1.24.4-darwin
1.24.4-main-debian10-fips
1.24.4-main-debian10
1.24.4-main-debian11-fips
1.24.4-main-debian11
1.24.4-main-debian12-fips
1.24.4-main-debian12
1.24.4-main-debian7-fips
1.24.4-main-debian7
1.24.4-main-debian9-fips
1.24.4-main-debian9
1.24.4-main-fips
1.24.4-main
1.24.4-mips-debian12-fips
1.24.4-mips-debian12
1.24.4-ppc-debian12-fips
1.24.4-ppc-debian12
1.24.4-s390x-debian12-fips
1.24.4-s390x-debian12
```

So I could update the container tags we use accordingly. 