### PR TITLE
Reintroduce debian8 publishing for go 1.24

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -119,6 +119,7 @@ steps:
             makefile:
               - "Makefile"
               - "Makefile.debian7"
+              - "Makefile.debian8"
               - "Makefile.debian9"
               - "Makefile.debian10"
               - "Makefile.debian11"
@@ -151,6 +152,7 @@ steps:
         matrix:
           setup:
             makefile:
+              - "Makefile.debian8"
               - "Makefile.debian9"
               - "Makefile.debian10"
               - "Makefile.debian11"
@@ -186,6 +188,7 @@ steps:
             makefile:
               - "Makefile"
               - "Makefile.debian7"
+              - "Makefile.debian8"
               - "Makefile.debian9"
               - "Makefile.debian10"
               - "Makefile.debian11"
@@ -218,6 +221,7 @@ steps:
         matrix:
           setup:
             makefile:
+              - "Makefile.debian8"
               - "Makefile.debian9"
               - "Makefile.debian10"
               - "Makefile.debian11"

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ build:
 	@$(foreach var,$(TARGETS), \
 		$(MAKE) -C $(var) $@ || echo '1' > ${status}; \
 		$(MAKE) -C $(var) -f Makefile.debian7 $@ || echo '1' > ${status}; \
+		$(MAKE) -C $(var) -f Makefile.debian8 $@ || echo '1' > ${status}; \
 		$(MAKE) -C $(var) -f Makefile.debian9 $@ || echo '1' > ${status}; \
 		$(MAKE) -C $(var) -f Makefile.debian10 $@ || echo '1' > ${status}; \
 		$(MAKE) -C $(var) -f Makefile.debian11 $@ || echo '1' > ${status}; \
@@ -33,6 +34,7 @@ push:
 	@$(foreach var,$(TARGETS), \
 		$(MAKE) -C $(var) $@ || echo '1' > ${status}; \
 		$(MAKE) -C $(var) -f Makefile.debian7 $@ || echo '1' > ${status}; \
+		$(MAKE) -C $(var) -f Makefile.debian8 $@ || echo '1' > ${status}; \
 		$(MAKE) -C $(var) -f Makefile.debian9 $@ || echo '1' > ${status}; \
 		$(MAKE) -C $(var) -f Makefile.debian10 $@ || echo '1' > ${status}; \
 		$(MAKE) -C $(var) -f Makefile.debian11 $@ || echo '1' > ${status}; \

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ The file `go/Makefile.common` is the default Makefile used to build the Docker i
 There is additional Makefile for each Debian version that is used to build the Docker images for that Debian version.
 
 * `go/Makefile.debian7`
+* `go/Makefile.debian8`
 * `go/Makefile.debian9`
 * `go/Makefile.debian10`
 * `go/Makefile.debian11`

--- a/go/Makefile.debian8
+++ b/go/Makefile.debian8
@@ -1,0 +1,22 @@
+IMAGES         := base main darwin npcap
+ARM_IMAGES     := base-arm
+DEBIAN_VERSION := 8
+TAG_EXTENSION  := -debian8
+
+export DEBIAN_VERSION TAG_EXTENSION
+
+build:
+	export |grep TAG_EXTENSION
+	@$(foreach var,$(IMAGES),$(MAKE) -C $(var) build || exit 1;)
+
+build-arm:
+	@$(foreach var,$(ARM_IMAGES),$(MAKE) -C $(var) build-arm || exit 1;)
+
+# Requires login at https://docker.elastic.co:7000/.
+push:
+	@$(foreach var,$(IMAGES),$(MAKE) -C $(var) push || exit 1;)
+
+push-arm:
+	@$(foreach var,$(ARM_IMAGES),$(MAKE) -C $(var) push-arm || exit 1;)
+
+.PHONY: build build-arm push push-arm

--- a/go/base-arm/Dockerfile.tmpl
+++ b/go/base-arm/Dockerfile.tmpl
@@ -27,7 +27,13 @@ RUN \
             libicu-dev \
             icu-devtools \
             libsystemd-dev \
-            {{- if eq .DEBIAN_VERSION "9" }}
+            {{- if eq .DEBIAN_VERSION "8" }}
+            libicu52 \
+            librpm3  \
+            librpmio3 \
+            librpmbuild3 \
+            librpmsign1 \
+            {{- else if eq .DEBIAN_VERSION "9" }}
             libicu57 \
             librpm3  \
             librpmio3 \

--- a/go/base-arm/sources-debian8.list
+++ b/go/base-arm/sources-debian8.list
@@ -1,0 +1,1 @@
+deb [arch=arm64] http://archive.debian.org/debian jessie main


### PR DESCRIPTION
Reintroduce support for golang 1.24 on debian 8 as it is needed by https://github.com/elastic/beats/pull/43984. Respective BK failure on beats https://buildkite.com/elastic/filebeat/builds/18906#01977d68-385f-4569-9f98-216d839be34a/157-231