### PR TITLE
Fix bump MS Golang bump in 1.23

### DIFF
--- a/.github/updatecli.d/bump-go-microsoft-version.sh
+++ b/.github/updatecli.d/bump-go-microsoft-version.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#
+# Given the Golang microsoft version this script will bump the version.
+#
+# This script is executed by the automation we are putting in place
+#
+# Parameters:
+#	$1 -> the Golang release version to be bumped. Mandatory.
+#
+set -euo pipefail
+MSG="parameter missing."
+GO_RELEASE_VERSION=${1:?$MSG}
+OS=$(uname -s| tr '[:upper:]' '[:lower:]')
+if [ "${OS}" == "darwin" ] ; then
+	SED="sed -i .bck"
+else
+	SED="sed -i"
+fi
+
+MAJOR_MINOR_PATCH_VERSION=$(echo "$GO_RELEASE_VERSION" | sed -E -e "s#([0-9]+\.[0-9]+\.[0-9]+).*#\1#g")
+SECURITY_VERSION=$(echo "$GO_RELEASE_VERSION" | sed -E -e "s#([0-9]+\.[0-9]+\.[0-9]+)(.+)#\2#g")
+
+# Gather microsoft/go sha256 values
+MSFT_DOWNLOAD_METADATA=$(curl -s -L https://aka.ms/golang/release/latest/go${MAJOR_MINOR_PATCH_VERSION}.assets.json)
+MSFT_DOWNLOAD_SHA256_ARM=$(echo $MSFT_DOWNLOAD_METADATA | jq -r ".arches[] | select( .env.GOOS == \"linux\") | select( .env.GOARCH == \"arm64\") | .sha256")
+MSFT_DOWNLOAD_SHA256_AMD=$(echo $MSFT_DOWNLOAD_METADATA | jq -r ".arches[] | select( .env.GOOS == \"linux\") | select( .env.GOARCH == \"amd64\") | .sha256")
+
+echo "Update go version ${GO_RELEASE_VERSION}"
+
+find "go" -type f -name Dockerfile.tmpl -print0 |
+    while IFS= read -r -d '' line; do
+        ${SED} -E -e "s#(ARG SECURITY_VERSION)=.*#\1=${SECURITY_VERSION}#g" "$line"
+        if echo "$line" | grep -q 'arm' ; then
+            ${SED} -E -e "s#(ARG MSFT_DOWNLOAD_SHA256)=.+#\1=${MSFT_DOWNLOAD_SHA256_ARM}#g" "$line"
+        else
+            ${SED} -E -e "s#(ARG MSFT_DOWNLOAD_SHA256)=.+#\1=${MSFT_DOWNLOAD_SHA256_AMD}#g" "$line"
+        fi
+    done

--- a/.github/workflows/bump-golang-previous.yml
+++ b/.github/workflows/bump-golang-previous.yml
@@ -20,9 +20,9 @@ jobs:
       - uses: ./.github/actions/bump-golang
         with:
           # NOTE: when a new golang version please update me with 1.<go-version-1>
-          branch: '1.22'
+          branch: '1.23'
           # NOTE: when a new golang version please update me with 1.<go-version-1>
-          go-minor: '1.22'
+          go-minor: '1.23'
           command: '--experimental apply'
           slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/bump-golang.yml
+++ b/.github/workflows/bump-golang.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           branch: 'main'
           # NOTE: when a new golang version please update me with 1.<go-version>
-          go-minor: '1.23'
+          go-minor: '1.24'
           command: '--experimental apply'
           slack-bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This commit fixes the Goland bump GH action in the 1.23 branch which is failing due to a missing script.

This was the failure observed: https://github.com/elastic/golang-crossbuild/actions/runs/15723702898/job/44309400069#step:3:349