### PR TITLE
bk: avoid running LLVM on a schedule event

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -82,9 +82,9 @@ steps:
                       - BUILDKITE_PULL_REQUEST_BASE_BRANCH=${BUILDKITE_PULL_REQUEST_BASE_BRANCH}
                       - GITHUB_PR_LABELS=${GITHUB_PR_LABELS}
 
-      # Trigger for the main branch only
+      # Trigger for the main branch only if no a scheduled build
       - label: ":pipeline: Upload llvm-apple Pipeline"
-        if: build.branch == 'main'
+        if: build.branch == 'main' && build.source != "schedule"
         command: "buildkite-agent pipeline upload .buildkite/llvm-apple-pipeline.yml"
         env:
           - BUILDKITE_PULL_REQUEST=${BUILDKITE_PULL_REQUEST}


### PR DESCRIPTION
### What

Let's avoid running it as it notifies failures.

### Why

If https://github.com/elastic/golang-crossbuild/issues/615 is not solved, avoid running it since we are comfortable with seeing those failures and doing nothing.