### PR TITLE
bk: use our vm images

### DIFF
--- a/.buildkite/fpm-pipeline.yml
+++ b/.buildkite/fpm-pipeline.yml
@@ -2,7 +2,7 @@
 
 env:
   SETUP_GVM_VERSION: "v0.5.1"
-  IMAGE_UBUNTU_X86_64: "family/core-ubuntu-2204"
+  IMAGE_UBUNTU_X86_64: "family/platform-ingest-beats-ubuntu-2204"
   STAGING_IMAGE: "docker.elastic.co/observability-ci"
   MAKEFILE: "fpm"
   BUILDX: "0"

--- a/.buildkite/llvm-apple-pipeline.yml
+++ b/.buildkite/llvm-apple-pipeline.yml
@@ -2,8 +2,8 @@
 
 env:
   SETUP_GVM_VERSION: "v0.5.1"
-  IMAGE_UBUNTU_X86_64: "family/core-ubuntu-2204"
-  IMAGE_UBUNTU_ARM_64: "core-ubuntu-2004-aarch64"
+  IMAGE_UBUNTU_X86_64: "family/platform-ingest-beats-ubuntu-2204"
+  IMAGE_UBUNTU_ARM_64: "platform-ingest-beats-ubuntu-2204-aarch64"
   STAGING_IMAGE: "docker.elastic.co/observability-ci"
   MAKEFILE: "go/llvm-apple"
   BUILDX: "0"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,7 +4,7 @@ env:
   SETUP_GVM_VERSION: "v0.5.1"
   IMAGE_UBUNTU_X86_64: "family/platform-ingest-beats-ubuntu-2204"
   INSTANCE_TYPE_X86_64: "n2-standard-4"
-  IMAGE_UBUNTU_ARM_64: "core-ubuntu-2004-aarch64"
+  IMAGE_UBUNTU_ARM_64: "platform-ingest-beats-ubuntu-2204-aarch64"
   STAGING_IMAGE: "docker.elastic.co/observability-ci"
   BUILDX: 1
 


### PR DESCRIPTION
https://github.com/elastic/golang-crossbuild/pull/326 was the original request that enabled those core images, https://github.com/elastic/golang-crossbuild/pull/507 introduced our core images.

Let's normalise and use those images everywhere! And avoid using 2004 

llvm-apple will fail - already reported https://github.com/elastic/golang-crossbuild/issues/651


Closes https://github.com/elastic/golang-crossbuild/issues/660
