### PR TITLE
Fix typo in release-drafter.yml

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -14,7 +14,7 @@ categories:
       - 'docs'
       - 'question'
   - title: '🧰 Maintenance'
-    label:
+    labels:
       - 'chore'
       - 'ci'
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'


### PR DESCRIPTION
This is failing release drafts. See https://github.com/elastic/golang-crossbuild/actions/runs/25566812037.

The action was upgraded to v7, and is now less permissive about input types.