### PR TITLE
Allow running crossbuild as a non-root user

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,49 @@ This will execute your projects `make build` target. While executing the build
 command the following variables with be added to the environment: GOOS, GOARCH,
 GOARM, PLATFORM_ID, CC, and CXX.
 
+### Running as a non-root user
+
+By default the container runs as root, which causes build output files on a
+bind-mounted workspace to be owned by `root` on the host. To avoid this, pass
+`CROSSBUILD_UID` and `CROSSBUILD_GID` matching your host user:
+
+```shell
+docker run -it --rm \
+  -v $GOPATH/src/github.com/user/go-project:/go/src/github.com/user/go-project \
+  -w /go/src/github.com/user/go-project \
+  -e CGO_ENABLED=1 \
+  -e CROSSBUILD_UID=$(id -u) \
+  -e CROSSBUILD_GID=$(id -g) \
+  docker.elastic.co/beats-dev/golang-crossbuild:1.16.7-armhf \
+  --build-cmd "make build" \
+  -p "linux/armv7"
+```
+
+When both variables are set the entrypoint creates an ephemeral user inside the
+container with that UID/GID and drops privileges before running the build.
+Files written to the mounted workspace will then be owned by your host user.
+If neither variable is set the container behaves as before (runs as root).
+
+`GOCACHE` and `GOMODCACHE` default to paths inside the ephemeral home directory
+but are only set if not already present in the environment. You can therefore
+mount your host Go caches directly:
+
+```shell
+docker run -it --rm \
+  -v $GOPATH/src/github.com/user/go-project:/go/src/github.com/user/go-project \
+  -v $HOME/.cache/go-build:/go-cache \
+  -v $GOPATH/pkg/mod:/go-mod \
+  -w /go/src/github.com/user/go-project \
+  -e CGO_ENABLED=1 \
+  -e CROSSBUILD_UID=$(id -u) \
+  -e CROSSBUILD_GID=$(id -g) \
+  -e GOCACHE=/go-cache \
+  -e GOMODCACHE=/go-mod \
+  docker.elastic.co/beats-dev/golang-crossbuild:1.16.7-armhf \
+  --build-cmd "make build" \
+  -p "linux/armv7"
+```
+
 ## fpm Docker image
 
 This Docker image install the [fpm](https://github.com/jordansissel/fpm) tool that is used to build packages.

--- a/go/base-arm/Dockerfile.tmpl
+++ b/go/base-arm/Dockerfile.tmpl
@@ -63,6 +63,18 @@ RUN \
             libsqlite3-0 \
         && rm -rf /var/lib/apt/lists/*
 
+ARG SUEXEC_VERSION=0.2
+ARG SUEXEC_DOWNLOAD_URL=https://github.com/ncopa/su-exec/archive/v${SUEXEC_VERSION}.tar.gz
+ARG SUEXEC_DOWNLOAD_SHA256=ec4acbd8cde6ceeb2be67eda1f46c709758af6db35cacbcde41baac349855e25
+
+RUN curl -fsSL "$SUEXEC_DOWNLOAD_URL" -o suexec.tar.gz \
+    && echo "$SUEXEC_DOWNLOAD_SHA256  suexec.tar.gz" | sha256sum -c - \
+    && mkdir /suexec \
+    && tar -C /suexec --strip-components=1 -xzf suexec.tar.gz \
+    && make -C /suexec \
+    && mv /suexec/su-exec /usr/bin/ \
+    && rm -rf /suexec suexec.tar.gz
+
 ARG VERSION
 {{- if eq .FIPS "true"}}
 ARG SECURITY_VERSION=-1
@@ -123,4 +135,4 @@ ENV MS_GOTOOLCHAIN_TELEMETRY_ENABLED=0
 ENV GOLANG_CROSSBUILD=1
 VOLUME      /app
 WORKDIR     /app
-ENTRYPOINT  ["/crossbuild"]
+ENTRYPOINT  ["/entrypoint.sh"]

--- a/go/base-arm/rootfs/entrypoint.sh
+++ b/go/base-arm/rootfs/entrypoint.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env sh
+set -e
+
+if [ -n "${CROSSBUILD_UID+x}" ] && [ -n "${CROSSBUILD_GID+x}" ]; then
+    groupadd -f -g "$CROSSBUILD_GID" crossbuild 2>/dev/null || true
+    useradd -N -m -c 'Crossbuild User' -u "$CROSSBUILD_UID" -g "$CROSSBUILD_GID" crossbuild 2>/dev/null || true
+    export HOME="/home/crossbuild"
+    export GOCACHE="${GOCACHE:-$HOME/.cache/go-build}"
+    export GOMODCACHE="${GOMODCACHE:-$HOME/go/pkg/mod}"
+    mkdir -p "$HOME/.config/go/telemetry" "$GOCACHE" "$GOMODCACHE"
+    printf 'off\n' > "$HOME/.config/go/telemetry/mode"
+    chown -R "$CROSSBUILD_UID:$CROSSBUILD_GID" "$HOME"
+    exec su-exec crossbuild /crossbuild "$@"
+fi
+
+exec /crossbuild "$@"

--- a/go/base/Dockerfile.tmpl
+++ b/go/base/Dockerfile.tmpl
@@ -27,6 +27,18 @@ RUN apt-get -o Acquire::Check-Valid-Until=false update -y --no-install-recommend
 {{- end }}
         && rm -rf /var/lib/apt/lists/*
 
+ARG SUEXEC_VERSION=0.2
+ARG SUEXEC_DOWNLOAD_URL=https://github.com/ncopa/su-exec/archive/v${SUEXEC_VERSION}.tar.gz
+ARG SUEXEC_DOWNLOAD_SHA256=ec4acbd8cde6ceeb2be67eda1f46c709758af6db35cacbcde41baac349855e25
+
+RUN curl -fsSL "$SUEXEC_DOWNLOAD_URL" -o suexec.tar.gz \
+    && echo "$SUEXEC_DOWNLOAD_SHA256  suexec.tar.gz" | sha256sum -c - \
+    && mkdir /suexec \
+    && tar -C /suexec --strip-components=1 -xzf suexec.tar.gz \
+    && make -C /suexec \
+    && mv /suexec/su-exec /usr/bin/ \
+    && rm -rf /suexec suexec.tar.gz
+
 {{- if eq .DEBIAN_VERSION "10"}}
 RUN ln -s /usr/bin/pip3 /usr/bin/pip
 {{- end }}
@@ -89,4 +101,4 @@ ENV MS_GOTOOLCHAIN_TELEMETRY_ENABLED=0
 ENV GOLANG_CROSSBUILD=1
 VOLUME      /app
 WORKDIR     /app
-ENTRYPOINT  ["/crossbuild"]
+ENTRYPOINT  ["/entrypoint.sh"]

--- a/go/base/rootfs/entrypoint.sh
+++ b/go/base/rootfs/entrypoint.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env sh
+set -e
+
+if [ -n "${CROSSBUILD_UID+x}" ] && [ -n "${CROSSBUILD_GID+x}" ]; then
+    groupadd -f -g "$CROSSBUILD_GID" crossbuild 2>/dev/null || true
+    useradd -N -m -c 'Crossbuild User' -u "$CROSSBUILD_UID" -g "$CROSSBUILD_GID" crossbuild 2>/dev/null || true
+    export HOME="/home/crossbuild"
+    export GOCACHE="${GOCACHE:-$HOME/.cache/go-build}"
+    export GOMODCACHE="${GOMODCACHE:-$HOME/go/pkg/mod}"
+    mkdir -p "$HOME/.config/go/telemetry" "$GOCACHE" "$GOMODCACHE"
+    printf 'off\n' > "$HOME/.config/go/telemetry/mode"
+    chown -R "$CROSSBUILD_UID:$CROSSBUILD_GID" "$HOME"
+    exec su-exec crossbuild /crossbuild "$@"
+fi
+
+exec /crossbuild "$@"


### PR DESCRIPTION
Allow the image to run with a provided UID and GID. This is done by setting the `CROSSBUILD_UID` and `CROSSBUILD_GID` environment variables. If they're set, the entrypoint creates the user and takes care of the requisite bureaucracy. If they're unset, nothing changes, other than the presence of the `su-exec` binary in the image.

Resolves https://github.com/elastic/golang-crossbuild/issues/732.