### PR TITLE
Register Buildkite pipeline for automated npcap bump

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -154,6 +154,8 @@ spec:
           access_level: MANAGE_BUILD_AND_READ
         observablt-robots:
           access_level: BUILD_AND_READ
+        endpoint-ci-admin:
+          access_level: BUILD_AND_READ
         everyone:
           access_level: READ_ONLY
       schedules:

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -118,6 +118,55 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Resource
 metadata:
+  name: buildkite-pipeline-golang-crossbuild-bump-npcap
+  description: 'Scheduled pipeline to detect new npcap releases, upload the OEM installer to GCS, and open PRs in golang-crossbuild and elastic/beats'
+  links:
+    - title: Pipeline
+      url: https://buildkite.com/elastic/golang-crossbuild-bump-npcap
+
+spec:
+  type: buildkite-pipeline
+  owner: group:ingest-fp
+  system: buildkite
+  implementation:
+    apiVersion: buildkite.elastic.dev/v1
+    kind: Pipeline
+    metadata:
+      name: golang-crossbuild-bump-npcap
+      description: 'Scheduled pipeline to detect new npcap releases, upload the OEM installer to GCS, and open PRs in golang-crossbuild and elastic/beats'
+    spec:
+      branch_configuration: "main"
+      pipeline_file: ".buildkite/bump-npcap-pipeline.yml"
+      maximum_timeout_in_minutes: 30
+      provider_settings:
+        build_tags: false
+        publish_commit_status: false
+        build_pull_request_forks: false
+        build_pull_requests: false
+        filter_enabled: false
+      repository: elastic/golang-crossbuild
+      cancel_intermediate_builds: false
+      skip_intermediate_builds: false
+      env:
+        ELASTIC_PR_COMMENTS_ENABLED: 'false'
+      teams:
+        ingest-fp:
+          access_level: MANAGE_BUILD_AND_READ
+        observablt-robots:
+          access_level: BUILD_AND_READ
+        everyone:
+          access_level: READ_ONLY
+      schedules:
+        Weekly:
+          branch: main
+          cronline: "0 4 * * 1 America/New_York"
+          message: "Weekly check for new npcap release"
+
+---
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
   name: buildkite-pipeline-fpm
   description: "Pipeline for FPM (packaging made simple)"
   links:


### PR DESCRIPTION
## Summary

Registers the `golang-crossbuild-bump-npcap` Buildkite pipeline by adding it to `catalog-info.yaml`. Once merged, the RRE process will provision the pipeline at https://buildkite.com/elastic/golang-crossbuild-bump-npcap.

**This is PR 1 of 2.** A follow-up PR will add the pipeline YAML and scripts once the pipeline has been provisioned — the scripts rely on `buildkite-agent` being available, so they cannot be tested until the pipeline exists in Buildkite.

Closes https://github.com/elastic/ingest-dev/issues/2990

---

## Background

Updating the bundled npcap OEM installer in `elastic/beats` (used by Packetbeat on Windows) is currently a fully manual process:

1. A human notices a new [npcap release](https://github.com/nmap/npcap/releases)
2. They download the OEM installer from npcap.com using credentials stored in Vault
3. They upload it to `gs://golang-crossbuild-ci-internal/private/`
4. They open a PR in `elastic/golang-crossbuild` bumping `NPCAP_VERSION` in `Makefile.common` (e.g. [#710](https://github.com/elastic/golang-crossbuild/pull/710))
5. They open a PR in `elastic/beats` bumping the version in `x-pack/packetbeat/npcap/installer/LICENSE` and adding a changelog fragment (e.g. [elastic/beats#49167](https://github.com/elastic/beats/pull/49167))

This pipeline automates all five steps on a weekly schedule.

---

## What the pipeline will do (PR 2)

```
┌─────────────────────────────────────────────┐
│  Step 1: Check and upload npcap             │
│  • Query GitHub API for latest npcap tag    │
│  • Compare against NPCAP_VERSION in         │
│    Makefile.common                          │
│  • If newer: download OEM installer from    │
│    npcap.com (credentials from Vault)       │
│  • Upload to gs://golang-crossbuild-ci-     │
│    internal/private/ (GCP OIDC auth)        │
│  • Publish new version via BK meta-data     │
└───────────────────┬─────────────────────────┘
                    │ wait
          ┌─────────┴──────────┐
          ▼                    ▼
┌──────────────────┐  ┌──────────────────────┐
│ Step 2: Bump     │  │ Step 3: Bump npcap   │
│ golang-crossbuild│  │ in elastic/beats     │
│                  │  │                      │
│ • Bump           │  │ • Clone elastic/beats│
│   NPCAP_VERSION  │  │ • Bump version in    │
│   in             │  │   npcap/installer/   │
│   Makefile.common│  │   LICENSE            │
│ • Open PR here   │  │ • Write changelog    │
│                  │  │   fragment           │
│                  │  │ • Open PR in beats   │
└──────────────────┘  └──────────────────────┘
```

Steps 2 and 3 run in **parallel** — both are independent once the GCS upload is confirmed. Each step self-skips (`exit 0`) if no new version was detected.

## Pipeline configuration

- **Schedule**: Weekly, Monday 04:00 ET
- **Trigger**: Schedule only (`build_pull_requests: false`) — not PR-driven
- **GCP auth**: Reuses the existing `elastic/oblt-google-auth#v1.3.0` plugin already configured for this repo in `oblt-infra` — no infrastructure changes required
- **Secrets**: NPCAP OEM credentials read from Vault at `kv/ci-shared/observability-github-secrets/golang-crossbuild/` (populated via [elastic/observability-github-secrets#585](https://github.com/elastic/observability-github-secrets/pull/585)); GitHub operations use the existing `VAULT_GITHUB_TOKEN` (elasticmachine)

## Merge checklist

- [ ] Merge this PR
- [ ] Wait for the RRE process to provision the pipeline (confirm https://buildkite.com/elastic/golang-crossbuild-bump-npcap is live)
- [ ] Merge PR 2 (pipeline YAML + scripts) — will be opened once provisioning is confirmed
- [ ] Confirm [elastic/observability-github-secrets#585](https://github.com/elastic/observability-github-secrets/pull/585) is merged so the NPCAP Vault credentials are available
- [ ] Trigger the pipeline manually via the Buildkite UI to validate end-to-end