### PR TITLE
fix: Debian 11 EOL sources and apt sources/packages on Debian 12

### DIFF
--- a/go/base-arm/Dockerfile.tmpl
+++ b/go/base-arm/Dockerfile.tmpl
@@ -8,7 +8,7 @@ COPY sources-debian${DEBIAN_VERSION}.list /etc/apt/sources.list
 RUN \
     apt-get -o Acquire::Check-Valid-Until=false update \
         && apt-get dist-upgrade -y \
-        && apt-get install -qq -y --no-install-recommends --allow-unauthenticated --fix-missing \
+        && apt-get install -qq -y --no-install-recommends --allow-unauthenticated \
             build-essential \
             ca-certificates \
             curl \

--- a/go/base-arm/Dockerfile.tmpl
+++ b/go/base-arm/Dockerfile.tmpl
@@ -4,6 +4,9 @@ FROM arm64v8/debian:${DEBIAN_VERSION}
 ARG DEBIAN_VERSION
 # Replace sources.list in order to use archive.debian.org.
 COPY sources-debian${DEBIAN_VERSION}.list /etc/apt/sources.list
+# Debian 12+ ships /etc/apt/sources.list.d/debian.sources (DEB822 format); remove it so
+# only our sources.list is active and cross-arch packages resolve without version conflicts.
+RUN rm -f /etc/apt/sources.list.d/debian.sources
 
 RUN \
     apt-get -o Acquire::Check-Valid-Until=false update \

--- a/go/base-arm/Dockerfile.tmpl
+++ b/go/base-arm/Dockerfile.tmpl
@@ -8,7 +8,7 @@ COPY sources-debian${DEBIAN_VERSION}.list /etc/apt/sources.list
 RUN \
     apt-get -o Acquire::Check-Valid-Until=false update \
         && apt-get dist-upgrade -y \
-        && apt-get install -qq -y --no-install-recommends --allow-unauthenticated \
+        && apt-get install -qq -y --no-install-recommends --allow-unauthenticated --fix-missing \
             build-essential \
             ca-certificates \
             curl \

--- a/go/base-arm/sources-debian11.list
+++ b/go/base-arm/sources-debian11.list
@@ -1,4 +1,3 @@
 # see https://wiki.debian.org/CrossToolchains
-deb [arch=arm64] http://deb.debian.org/debian bullseye main
-deb [arch=arm64] http://deb.debian.org/debian bullseye-updates main
-deb [arch=arm64] http://deb.debian.org/debian-security/ bullseye-security main
+deb [arch=arm64] http://archive.debian.org/debian bullseye main
+deb [arch=arm64] http://archive.debian.org/debian-security bullseye-security main

--- a/go/base-arm/sources-debian11.list
+++ b/go/base-arm/sources-debian11.list
@@ -1,3 +1,3 @@
 # see https://wiki.debian.org/CrossToolchains
 deb [arch=arm64] http://archive.debian.org/debian bullseye main
-deb [arch=arm64] http://security.debian.org/debian-security bullseye-security main
+deb [arch=arm64 check-valid-until=no] http://snapshot.debian.org/archive/debian-security/20260820T000000Z/ bullseye-security main

--- a/go/base-arm/sources-debian11.list
+++ b/go/base-arm/sources-debian11.list
@@ -1,3 +1,3 @@
 # see https://wiki.debian.org/CrossToolchains
 deb [arch=arm64] http://archive.debian.org/debian bullseye main
-deb [arch=arm64] http://deb.debian.org/debian-security bullseye-security main
+deb [arch=arm64] http://security.debian.org/debian-security bullseye-security main

--- a/go/base-arm/sources-debian11.list
+++ b/go/base-arm/sources-debian11.list
@@ -1,2 +1,3 @@
 # see https://wiki.debian.org/CrossToolchains
 deb [arch=arm64] http://archive.debian.org/debian bullseye main
+deb [arch=arm64] http://deb.debian.org/debian-security bullseye-security main

--- a/go/base-arm/sources-debian11.list
+++ b/go/base-arm/sources-debian11.list
@@ -1,3 +1,2 @@
 # see https://wiki.debian.org/CrossToolchains
 deb [arch=arm64] http://archive.debian.org/debian bullseye main
-deb [arch=arm64] http://archive.debian.org/debian-security bullseye-security main

--- a/go/base-arm/sources-debian12.list
+++ b/go/base-arm/sources-debian12.list
@@ -1,3 +1,41 @@
 # see https://wiki.debian.org/CrossToolchains
 deb [arch=arm64] http://deb.debian.org/debian bookworm main
-deb [arch=arm64] http://deb.debian.org/debian-security/ bookworm-security main
+# TODO: bookworm-security is intentionally omitted.
+# libpcre2-8-0 and libselinux1 are Multi-Arch: same packages. The security repo
+# has amd64 updates (e.g. libpcre2-8-0 10.42-1+deb12u1) but the armel/armhf ports
+# have not yet published matching versions, so apt's M-A: same constraint prevents
+# installing those packages for foreign architectures alongside the security-patched
+# amd64 version. This breaks cross-arch images (go/armel, go/armhf, etc.).
+#
+# Alternatives considered:
+#   A) This approach: omit the security repo so all arches stay at consistent main-
+#      archive versions. Trade-off: amd64 packages in the base image lose security
+#      patches until the secondary ports catch up.
+#   B) APT pinning: pin the specific conflicting packages (libpcre2-8-0, libselinux1)
+#      to the main-archive version via /etc/apt/preferences.d/. Keeps security patches
+#      for everything else, but requires maintaining a hardcoded version list.
+#   C) Wait: once Debian publishes armel/armhf security updates for these packages,
+#      the M-A: same constraint is satisfied and this line can be restored with no
+#      other changes.
+#
+# To validate when it is safe to restore:
+#   Run the following and confirm that bookworm-security shows the same version
+#   for armel as it does for amd64 (both should be e.g. 10.42-1+deb12u1):
+#
+#   docker run --rm debian:12 bash -c '
+#     dpkg --add-architecture armel
+#     apt-get -qq update
+#     echo "--- amd64 ---"
+#     apt-cache madison libpcre2-8-0 | grep security
+#     echo "--- armel ---"
+#     apt-cache madison libpcre2-8-0:armel | grep security
+#     echo "--- libselinux1 amd64 ---"
+#     apt-cache madison libselinux1 | grep security
+#     echo "--- libselinux1 armel ---"
+#     apt-cache madison libselinux1:armel | grep security
+#   '
+#
+#   When all four "armel" lines show a version matching the "amd64" security
+#   version, uncomment the line below and remove this TODO block.
+#
+# deb [arch=arm64] http://deb.debian.org/debian-security/ bookworm-security main

--- a/go/base/Dockerfile.tmpl
+++ b/go/base/Dockerfile.tmpl
@@ -8,7 +8,7 @@ COPY sources-debian${DEBIAN_VERSION}.list /etc/apt/sources.list
 RUN apt-get -o Acquire::Check-Valid-Until=false update -y --no-install-recommends --allow-unauthenticated \
         && apt-get upgrade -y --no-install-recommends --allow-unauthenticated \
         && apt-get dist-upgrade -y --no-install-recommends --allow-unauthenticated \
-        && apt-get install -y --no-install-recommends --allow-unauthenticated --fix-missing \
+        && apt-get install -y --no-install-recommends --allow-unauthenticated \
             build-essential \
             ca-certificates \
             curl \

--- a/go/base/Dockerfile.tmpl
+++ b/go/base/Dockerfile.tmpl
@@ -8,7 +8,7 @@ COPY sources-debian${DEBIAN_VERSION}.list /etc/apt/sources.list
 RUN apt-get -o Acquire::Check-Valid-Until=false update -y --no-install-recommends --allow-unauthenticated \
         && apt-get upgrade -y --no-install-recommends --allow-unauthenticated \
         && apt-get dist-upgrade -y --no-install-recommends --allow-unauthenticated \
-        && apt-get install -y --no-install-recommends --allow-unauthenticated \
+        && apt-get install -y --no-install-recommends --allow-unauthenticated --fix-missing \
             build-essential \
             ca-certificates \
             curl \

--- a/go/base/Dockerfile.tmpl
+++ b/go/base/Dockerfile.tmpl
@@ -4,6 +4,9 @@ FROM debian:${DEBIAN_VERSION}
 ARG DEBIAN_VERSION
 # Replace sources.list in order to use archive.debian.org.
 COPY sources-debian${DEBIAN_VERSION}.list /etc/apt/sources.list
+# Debian 12+ ships /etc/apt/sources.list.d/debian.sources (DEB822 format); remove it so
+# only our sources.list is active and cross-arch packages resolve without version conflicts.
+RUN rm -f /etc/apt/sources.list.d/debian.sources
 
 RUN apt-get -o Acquire::Check-Valid-Until=false update -y --no-install-recommends --allow-unauthenticated \
         && apt-get upgrade -y --no-install-recommends --allow-unauthenticated \

--- a/go/base/sources-debian11.list
+++ b/go/base/sources-debian11.list
@@ -1,4 +1,3 @@
 # see https://wiki.debian.org/CrossToolchains
-deb http://deb.debian.org/debian bullseye main
-deb http://deb.debian.org/debian bullseye-updates main
-deb http://deb.debian.org/debian-security/ bullseye-security main
+deb http://archive.debian.org/debian bullseye main
+deb http://archive.debian.org/debian-security bullseye-security main

--- a/go/base/sources-debian11.list
+++ b/go/base/sources-debian11.list
@@ -1,2 +1,3 @@
 # see https://wiki.debian.org/CrossToolchains
 deb http://archive.debian.org/debian bullseye main
+deb http://deb.debian.org/debian-security bullseye-security main

--- a/go/base/sources-debian11.list
+++ b/go/base/sources-debian11.list
@@ -1,3 +1,2 @@
 # see https://wiki.debian.org/CrossToolchains
 deb http://archive.debian.org/debian bullseye main
-deb http://archive.debian.org/debian-security bullseye-security main

--- a/go/base/sources-debian11.list
+++ b/go/base/sources-debian11.list
@@ -1,3 +1,3 @@
 # see https://wiki.debian.org/CrossToolchains
 deb http://archive.debian.org/debian bullseye main
-deb http://deb.debian.org/debian-security bullseye-security main
+deb http://security.debian.org/debian-security bullseye-security main

--- a/go/base/sources-debian11.list
+++ b/go/base/sources-debian11.list
@@ -1,3 +1,3 @@
 # see https://wiki.debian.org/CrossToolchains
 deb http://archive.debian.org/debian bullseye main
-deb http://security.debian.org/debian-security bullseye-security main
+deb [check-valid-until=no] http://snapshot.debian.org/archive/debian-security/20260820T000000Z/ bullseye-security main

--- a/go/base/sources-debian12.list
+++ b/go/base/sources-debian12.list
@@ -1,3 +1,41 @@
 # see https://wiki.debian.org/CrossToolchains
 deb http://deb.debian.org/debian bookworm main
-deb http://deb.debian.org/debian-security/ bookworm-security main
+# TODO: bookworm-security is intentionally omitted.
+# libpcre2-8-0 and libselinux1 are Multi-Arch: same packages. The security repo
+# has amd64 updates (e.g. libpcre2-8-0 10.42-1+deb12u1) but the armel/armhf ports
+# have not yet published matching versions, so apt's M-A: same constraint prevents
+# installing those packages for foreign architectures alongside the security-patched
+# amd64 version. This breaks cross-arch images (go/armel, go/armhf, etc.).
+#
+# Alternatives considered:
+#   A) This approach: omit the security repo so all arches stay at consistent main-
+#      archive versions. Trade-off: amd64 packages in the base image lose security
+#      patches until the secondary ports catch up.
+#   B) APT pinning: pin the specific conflicting packages (libpcre2-8-0, libselinux1)
+#      to the main-archive version via /etc/apt/preferences.d/. Keeps security patches
+#      for everything else, but requires maintaining a hardcoded version list.
+#   C) Wait: once Debian publishes armel/armhf security updates for these packages,
+#      the M-A: same constraint is satisfied and this line can be restored with no
+#      other changes.
+#
+# To validate when it is safe to restore:
+#   Run the following and confirm that bookworm-security shows the same version
+#   for armel as it does for amd64 (both should be e.g. 10.42-1+deb12u1):
+#
+#   docker run --rm debian:12 bash -c '
+#     dpkg --add-architecture armel
+#     apt-get -qq update
+#     echo "--- amd64 ---"
+#     apt-cache madison libpcre2-8-0 | grep security
+#     echo "--- armel ---"
+#     apt-cache madison libpcre2-8-0:armel | grep security
+#     echo "--- libselinux1 amd64 ---"
+#     apt-cache madison libselinux1 | grep security
+#     echo "--- libselinux1 armel ---"
+#     apt-cache madison libselinux1:armel | grep security
+#   '
+#
+#   When all four "armel" lines show a version matching the "amd64" security
+#   version, uncomment the line below and remove this TODO block.
+#
+# deb http://deb.debian.org/debian-security/ bookworm-security main

--- a/go/llvm-apple/Dockerfile.tmpl
+++ b/go/llvm-apple/Dockerfile.tmpl
@@ -8,7 +8,7 @@ COPY sources-debian${DEBIAN_VERSION}.list /etc/apt/sources.list
 RUN apt-get -o Acquire::Check-Valid-Until=false update -y --no-install-recommends --allow-unauthenticated \
         && apt-get upgrade -y --no-install-recommends --allow-unauthenticated \
         && apt-get dist-upgrade -y --no-install-recommends --allow-unauthenticated \
-        && apt-get install -y --no-install-recommends --allow-unauthenticated --fix-missing \
+        && apt-get install -y --no-install-recommends --allow-unauthenticated \
             build-essential \
             ca-certificates \
             curl \

--- a/go/llvm-apple/Dockerfile.tmpl
+++ b/go/llvm-apple/Dockerfile.tmpl
@@ -8,7 +8,7 @@ COPY sources-debian${DEBIAN_VERSION}.list /etc/apt/sources.list
 RUN apt-get -o Acquire::Check-Valid-Until=false update -y --no-install-recommends --allow-unauthenticated \
         && apt-get upgrade -y --no-install-recommends --allow-unauthenticated \
         && apt-get dist-upgrade -y --no-install-recommends --allow-unauthenticated \
-        && apt-get install -y --no-install-recommends --allow-unauthenticated \
+        && apt-get install -y --no-install-recommends --allow-unauthenticated --fix-missing \
             build-essential \
             ca-certificates \
             curl \

--- a/go/llvm-apple/Dockerfile.tmpl
+++ b/go/llvm-apple/Dockerfile.tmpl
@@ -4,6 +4,9 @@ FROM debian:${DEBIAN_VERSION} AS BUILD_LLVM_APPLE
 ARG DEBIAN_VERSION
 # Replace sources.list in order to use archive.debian.org.
 COPY sources-debian${DEBIAN_VERSION}.list /etc/apt/sources.list
+# Debian 12+ ships /etc/apt/sources.list.d/debian.sources (DEB822 format); remove it so
+# only our sources.list is active and cross-arch packages resolve without version conflicts.
+RUN rm -f /etc/apt/sources.list.d/debian.sources
 
 RUN apt-get -o Acquire::Check-Valid-Until=false update -y --no-install-recommends --allow-unauthenticated \
         && apt-get upgrade -y --no-install-recommends --allow-unauthenticated \

--- a/go/llvm-apple/sources-debian11.list
+++ b/go/llvm-apple/sources-debian11.list
@@ -1,4 +1,3 @@
 # see https://wiki.debian.org/CrossToolchains
-deb http://deb.debian.org/debian bullseye main
-deb http://deb.debian.org/debian bullseye-updates main
-deb http://deb.debian.org/debian-security/ bullseye-security main
+deb http://archive.debian.org/debian bullseye main
+deb http://archive.debian.org/debian-security bullseye-security main

--- a/go/llvm-apple/sources-debian11.list
+++ b/go/llvm-apple/sources-debian11.list
@@ -1,2 +1,3 @@
 # see https://wiki.debian.org/CrossToolchains
 deb http://archive.debian.org/debian bullseye main
+deb http://deb.debian.org/debian-security bullseye-security main

--- a/go/llvm-apple/sources-debian11.list
+++ b/go/llvm-apple/sources-debian11.list
@@ -1,3 +1,2 @@
 # see https://wiki.debian.org/CrossToolchains
 deb http://archive.debian.org/debian bullseye main
-deb http://archive.debian.org/debian-security bullseye-security main

--- a/go/llvm-apple/sources-debian11.list
+++ b/go/llvm-apple/sources-debian11.list
@@ -1,3 +1,3 @@
 # see https://wiki.debian.org/CrossToolchains
 deb http://archive.debian.org/debian bullseye main
-deb http://deb.debian.org/debian-security bullseye-security main
+deb http://security.debian.org/debian-security bullseye-security main

--- a/go/llvm-apple/sources-debian11.list
+++ b/go/llvm-apple/sources-debian11.list
@@ -1,3 +1,3 @@
 # see https://wiki.debian.org/CrossToolchains
 deb http://archive.debian.org/debian bullseye main
-deb http://security.debian.org/debian-security bullseye-security main
+deb [check-valid-until=no] http://snapshot.debian.org/archive/debian-security/20260820T000000Z/ bullseye-security main

--- a/go/llvm-apple/sources-debian12.list
+++ b/go/llvm-apple/sources-debian12.list
@@ -1,3 +1,41 @@
 # see https://wiki.debian.org/CrossToolchains
 deb http://deb.debian.org/debian bookworm main
-deb http://deb.debian.org/debian-security/ bookworm-security main
+# TODO: bookworm-security is intentionally omitted.
+# libpcre2-8-0 and libselinux1 are Multi-Arch: same packages. The security repo
+# has amd64 updates (e.g. libpcre2-8-0 10.42-1+deb12u1) but the armel/armhf ports
+# have not yet published matching versions, so apt's M-A: same constraint prevents
+# installing those packages for foreign architectures alongside the security-patched
+# amd64 version. This breaks cross-arch images (go/armel, go/armhf, etc.).
+#
+# Alternatives considered:
+#   A) This approach: omit the security repo so all arches stay at consistent main-
+#      archive versions. Trade-off: amd64 packages in the base image lose security
+#      patches until the secondary ports catch up.
+#   B) APT pinning: pin the specific conflicting packages (libpcre2-8-0, libselinux1)
+#      to the main-archive version via /etc/apt/preferences.d/. Keeps security patches
+#      for everything else, but requires maintaining a hardcoded version list.
+#   C) Wait: once Debian publishes armel/armhf security updates for these packages,
+#      the M-A: same constraint is satisfied and this line can be restored with no
+#      other changes.
+#
+# To validate when it is safe to restore:
+#   Run the following and confirm that bookworm-security shows the same version
+#   for armel as it does for amd64 (both should be e.g. 10.42-1+deb12u1):
+#
+#   docker run --rm debian:12 bash -c '
+#     dpkg --add-architecture armel
+#     apt-get -qq update
+#     echo "--- amd64 ---"
+#     apt-cache madison libpcre2-8-0 | grep security
+#     echo "--- armel ---"
+#     apt-cache madison libpcre2-8-0:armel | grep security
+#     echo "--- libselinux1 amd64 ---"
+#     apt-cache madison libselinux1 | grep security
+#     echo "--- libselinux1 armel ---"
+#     apt-cache madison libselinux1:armel | grep security
+#   '
+#
+#   When all four "armel" lines show a version matching the "amd64" security
+#   version, uncomment the line below and remove this TODO block.
+#
+# deb http://deb.debian.org/debian-security/ bookworm-security main


### PR DESCRIPTION
### What

Two independent fixes:


#### 1. Debian 11 (Bullseye) — switch security source to snapshot.debian.org

Switch the bullseye-security source in all three sources-debian11.list files to a pinned [snapshot.debian.org](https://snapshot.debian.org/) snapshot dated 2026-08-20 (11 days before EOL), which is the approach [officially recommended by Debian](https://snapshot.debian.org/) for EOL releases. Unlike the CDN-backed mirrors, snapshot.debian.org is a proper archival service that retains all .deb files for historical snapshots.

#### 2. Debian 12 (Bookworm) — remove duplicate apt sources

Adds `RUN rm -f /etc/apt/sources.list.d/debian.sources` to all three base `Dockerfile.tmpl`
files, immediately after the `COPY sources.list` step. The `-f` flag makes this a no-op on
Debian 7–11 where the file does not exist.

Disable `bookworm-security` to unblock `armel/armhf` cross-arch builds". "libpcre2-8-0 and libselinux1 are Multi-Arch: same packages. The amd64 security repo has updated versions (e.g. `libpcre2-8-0 10.42-1+deb12u1`)
but the armel/armhf secondary ports have not yet published matching versions. apt's Multi-Arch: same constraint then prevents installing those packages for foreign architectures alongside the security-patched amd64 version, breaking go/armel and go/armhf cross-compilation images.

### Why

#### Debian 11

Debian 11 (Bullseye) LTS ended on `August 31, 2026`. After EOL, the Fastly CDN that backs both `security.debian.org` and `deb.debian.org` began evicting individual .deb package files from edge nodes, while still serving a stale InRelease index that references those files. This caused 404 errors on specific packages during Docker builds (e.g. perl, gnupg, curl, libperl5.32, python3.9-minimal) — packages that the `debian:11` base image already has pre-installed at their security-patched versions, making it impossible to remove the security repo entirely.

#### Debian 12

Debian 12 ships `/etc/apt/sources.list.d/debian.sources` in DEB822 format as the default.
When the Dockerfile COPYs `sources-debian12.list` to `/etc/apt/sources.list`, both files remain
active simultaneously, creating duplicate `bookworm-security` entries. This broke cross-arch
(`armel`, `armhf`) package installation:

- `libpcre2-dev:armel` requires `libpcre2-8-0:armel (= 10.42-1)` exactly, but the duplicate
  security source offered a patched version, making the exact-match constraint unsatisfiable
- `libselinux1:armel (= 3.4-1+b6)` is a binary-NMU absent from the security repo for `armel`,
  so it was not installable at all


### Issues

Follow-up https://github.com/elastic/golang-crossbuild/issues/756