### PR TITLE
fix: upgrade fpm image to debian:bookworm and fpm 1.18.0

### DIFF
--- a/fpm/Dockerfile.tmpl
+++ b/fpm/Dockerfile.tmpl
@@ -1,4 +1,4 @@
-FROM debian:bullseye
+FROM debian:bookworm
 LABEL maintainer="Elastic Beats Team"
 
 RUN \

--- a/fpm/Makefile
+++ b/fpm/Makefile
@@ -1,7 +1,7 @@
 include ../Makefile.common
 
 NAME    := fpm
-VERSION := 1.13.1
+VERSION := 1.18.0
 
 build:
 	@echo ">> Building $(REPOSITORY)/$(NAME):$(VERSION)$(SUFFIX)"


### PR DESCRIPTION
### What

Bump the base image to `debian:bookworm` (`Debian 12`, current stable).

Also bump fpm from 1.13.1 to 1.18.0.

### Why

`Debian 11 (Bullseye)` reached LTS EOL on `2026-08-31`. CDN mirrors now serve an expired Release file for bullseye-security, breaking apt-get update with:

```
  E: Release file for .../bullseye-security/InRelease is expired
```

Debian bookworm ships `Ruby 3.1.x`, which broke fpm 1.13.1 with Psych::DisallowedClass crashes and ERB API changes. These were fixed in the 1.15.x line and further improved through 1.18.0.


### Issues

Done in the past https://github.com/elastic/golang-crossbuild/pull/118
Part of https://github.com/elastic/golang-crossbuild/issues/760